### PR TITLE
RetryMiddleware: Allow fetchTimeout to be a function similar to retryDelays

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ import { RelayNetworkLayer } from 'react-relay-network-modern/es';
   * `header` - name of the HTTP header to pass the token in (default: `'Authorization'`).
   * If you use `auth` middleware with `retry`, `retry` must be used before `auth`. Eg. if token expired when retries apply, then `retry` can call `auth` middleware again.
 * **retryMiddleware** - for request retry if the initial request fails.
-  * `fetchTimeout` - number in milliseconds that defines in how much time will request timeout after it has been sent to the server again (default: `15000`).
+  * `fetchTimeout` - number in milliseconds that defines in how much time will request timeout after it has been sent to the server again (default: `15000`). Or it may be a function `(attempt: number) => number` which returns a timeout in milliseconds (`attempt` starts from 0).
   * `retryDelays` - array of millisecond that defines the values on which retries are based on (default: `[1000, 3000]`). Or it may be a function `(attempt: number) => number | false` which returns a timeout in milliseconds for retry or false for disabling retry (`attempt` starts from 0).
   * `statusCodes` - array of response status codes which will fire up retryMiddleware. Or it may be a function `(statusCode: number, req, res) => boolean` which makes retry if returned true. (default: `status < 200 or status > 300`).
   * `beforeRetry` - function(meta: { forceRetry: Function, abort: Function, delay: number, attempt: number, lastError: ?Error, req: RelayRequest }) called before every retry attempt. You get one argument with following properties:


### PR DESCRIPTION
Hello all,

My company has been religiously using this package for a while, but a new need has come up for us to be able to dynamically compute the timeout value to account for possible transient errors on our backend services.  This has been a huge component for us and I'm happy to be able to provide this functionality back to the community for others whom may also need this.

Please let me know what I can do to get this PR into a shape to be merged or whether this feature would ultimately be rejected.

Thanks so much for taking a look!