### PR TITLE
Surface errors from SSR middleware

### DIFF
--- a/src/__tests__/fetchWithMiddleware-test.js
+++ b/src/__tests__/fetchWithMiddleware-test.js
@@ -4,6 +4,7 @@
 import fetchMock from 'fetch-mock';
 import fetchWithMiddleware from '../fetchWithMiddleware';
 import RelayRequest from '../RelayRequest';
+import RelayResponse from '../RelayResponse';
 
 describe('fetchWithMiddleware', () => {
   beforeEach(() => {
@@ -151,6 +152,23 @@ describe('fetchWithMiddleware', () => {
     } catch (e) {
       expect(e instanceof Error).toBeTruthy();
       expect(e.toString()).toMatch('Server return empty response.data');
+    }
+  });
+
+  it('should fail correctly with a response from a middleware cache', async () => {
+    const middleware = () => async () =>
+      RelayResponse.createFromGraphQL({
+        errors: [{ message: 'A GraphQL error occurred' }],
+      });
+
+    const req = new RelayRequest(({}: any), {}, {}, null);
+
+    expect.hasAssertions();
+    try {
+      await fetchWithMiddleware(req, [middleware], []);
+    } catch (e) {
+      expect(e instanceof Error).toBeTruthy();
+      expect(e.toString()).toMatch('A GraphQL error occurred');
     }
   });
 });

--- a/src/createRequestError.js
+++ b/src/createRequestError.js
@@ -58,16 +58,16 @@ export function createRequestError(req: RelayRequestAny, res?: RelayResponse) {
 
   if (!res) {
     errorReason = 'Server return empty response.';
-  } else if (!res.json) {
-    errorReason =
-      (res.text ? res.text : `Server return empty response with Status Code: ${res.status}.`) +
-      (res ? `\n\n${res.toString()}` : '');
   } else if (res.errors) {
     if (req instanceof RelayRequest) {
       errorReason = formatGraphQLErrors(req, res.errors);
     } else {
       errorReason = JSON.stringify(res.errors);
     }
+  } else if (!res.json) {
+    errorReason =
+      (res.text ? res.text : `Server return empty response with Status Code: ${res.status}.`) +
+      (res ? `\n\n${res.toString()}` : '');
   } else if (!res.data) {
     errorReason = 'Server return empty response.data.\n\n' + res.toString();
   }

--- a/src/middlewares/__tests__/retry-test.js
+++ b/src/middlewares/__tests__/retry-test.js
@@ -161,7 +161,7 @@ describe('middlewares/retry', () => {
                   status: 200,
                   body: { data: 'PAYLOAD' },
                 }),
-              30,
+              30
             );
           });
         },
@@ -170,14 +170,13 @@ describe('middlewares/retry', () => {
 
       const rnl = new RelayNetworkLayer([
         retryMiddleware({
-          fetchTimeout: (attempt) => attempt < 2 ? 5 : 100,
+          fetchTimeout: attempt => (attempt < 2 ? 5 : 100),
           retryDelays: () => 1,
           logger: false,
         }),
       ]);
 
-      const mockReqExecution = mockReq(1).execute(rnl);
-
+      mockReq(1).execute(rnl);
       await sleep(60);
 
       expect(fetchMock.calls('/graphql')).toHaveLength(3);


### PR DESCRIPTION
When the SSR middleware creates a response object [here](https://github.com/relay-tools/react-relay-network-modern-ssr/blob/0c111652cdee1882dd03d4e0cae69111c8c09f88/src/server.js#L73), the response object will not have a `.json` property, but it will have `.data` and/or `.errors` properties. Without this change the actual underlying GraphQL error would not get surfaced, instead it would always go into the `!res.json` branch.

Also see https://github.com/artsy/force/pull/3261