### PR TITLE
feat(retryMiddleware): aborted with custom message

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ import { RelayNetworkLayer } from 'react-relay-network-modern/es';
   * `statusCodes` - array of response status codes which will fire up retryMiddleware. Or it may be a function `(statusCode: number, req, res) => boolean` which makes retry if returned true. (default: `status < 200 or status > 300`).
   * `beforeRetry` - function(meta: { forceRetry: Function, abort: Function, delay: number, attempt: number, lastError: ?Error, req: RelayRequest }) called before every retry attempt. You get one argument with following properties:
     * `forceRetry()` - for proceeding request immediately
-    * `abort()` - for aborting retry request
+    * `abort(abortMsg: string)` - for aborting retry request. (Default abort message is: `"Aborted in beforeRetry() callback"`)
     * `attempt` - number of the attemp (starts from 1)
     * `delay` - number of milliseconds when next retry will be called
     * `lastError` - will keep Error from previous request

--- a/src/middlewares/__tests__/retry-test.js
+++ b/src/middlewares/__tests__/retry-test.js
@@ -343,6 +343,7 @@ describe('middlewares/retry', () => {
       // First request will be fulfilled after 100ms delay
       // 2nd request and further - without delays
       let attempt = 0;
+      const customAbortedMsg = 'custom aborted in before beforeRetry';
       fetchMock.mock({
         matcher: '/graphql',
         response: () => {
@@ -363,7 +364,7 @@ describe('middlewares/retry', () => {
 
       // will call force retry after 30 ms
       const beforeRetry = jest.fn(({ abort }) => {
-        abort();
+        abort(customAbortedMsg);
       });
 
       const rnl = new RelayNetworkLayer([
@@ -397,7 +398,7 @@ describe('middlewares/retry', () => {
         req: expect.anything(),
       });
 
-      await expect(resPromise).rejects.toThrow('Aborted in beforeRetry() callback');
+      await expect(resPromise).rejects.toThrow(customAbortedMsg);
 
       // we should not make second request
       expect(fetchMock.calls('/graphql')).toHaveLength(1);

--- a/src/middlewares/retry.js
+++ b/src/middlewares/retry.js
@@ -9,10 +9,11 @@ import RRNLError from '../RRNLError';
 export type RetryAfterFn = (attempt: number) => number | false;
 export type TimeoutAfterFn = (attempt: number) => number;
 export type ForceRetryFn = (runNow: Function, delay: number) => any;
+export type AbortFn = (msg: ?string) => any;
 
 export type BeforeRetryCb = (meta: {|
   forceRetry: Function,
-  abort: Function,
+  abort: AbortFn,
   delay: number,
   attempt: number,
   lastError: ?Error,
@@ -214,12 +215,12 @@ export function delayedExecution<T>(
   const promise = new Promise((resolve, reject) => {
     let delayId;
 
-    abort = () => {
+    abort = msg => {
       if (delayId) {
         clearTimeout(delayId);
         delayId = null;
       }
-      reject(new RRNLRetryMiddlewareError('Aborted in beforeRetry() callback'));
+      reject(new RRNLRetryMiddlewareError(msg || 'Aborted in beforeRetry() callback'));
     };
 
     forceExec = () => {


### PR DESCRIPTION
* support aborted with custom message in beforeRetry
if pass msg to `abort` will throw Error with the passed msg
else use default msg
* add new type `AbortFn`

fix: #53