### PR TITLE
Add cancel functionality to requests

### DIFF
--- a/src/__mocks__/mockReq.js
+++ b/src/__mocks__/mockReq.js
@@ -62,10 +62,19 @@ class MockReq {
 
     const res = (rnl.fetchFn(operation, variables, cacheConfig, uploadables): any);
 
+    const promise = new Promise((resolve, reject) => {
+      res.subscribe({
+        complete: () => {},
+        error: (error) => reject(error),
+        next: (value) => resolve(value),
+      });
+    });
+
     // avoid unhandled rejection in tests
-    res.catch(() => {});
+    promise.catch(() => {});
+
     // but allow to read rejected response
-    return res;
+    return promise;
   }
 }
 

--- a/src/definition.js
+++ b/src/definition.js
@@ -98,8 +98,17 @@ export type QueryPayload =
       rerunVariables?: Variables,
     |}
   | RelayResponse;
+
+export type UnsubscribeFunction = () => void;
+export type Sink<T> = {
+  next: (value: T) => void,
+  complete: () => void,
+  error: (value: T) => void,
+};
 // this is workaround should be class from relay-runtime/network/RelayObservable.js
-export type RelayObservable<T> = Promise<T>;
+export type RelayObservable<T> = {
+  subscribe: (sink: Sink<T>) => UnsubscribeFunction,
+};
 // Note: This should accept Subscribable<T> instead of RelayObservable<T>,
 // however Flow cannot yet distinguish it from T.
 export type ObservableFromValue<T> = RelayObservable<T> | Promise<T> | T;

--- a/src/middlewares/__tests__/__snapshots__/auth-test.js.snap
+++ b/src/middlewares/__tests__/__snapshots__/auth-test.js.snap
@@ -9,6 +9,7 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
+  "signal": AbortSignal {},
 }
 `;
 
@@ -21,6 +22,7 @@ Object {
     "MyAuthorization": "MyBearer 333",
   },
   "method": "POST",
+  "signal": AbortSignal {},
 }
 `;
 
@@ -36,6 +38,7 @@ Array [
         "Content-Type": "application/json",
       },
       "method": "POST",
+      "signal": AbortSignal {},
     },
   ],
   Array [
@@ -48,6 +51,7 @@ Array [
         "Content-Type": "application/json",
       },
       "method": "POST",
+      "signal": AbortSignal {},
     },
   ],
 ]

--- a/src/middlewares/__tests__/__snapshots__/batch-test.js.snap
+++ b/src/middlewares/__tests__/__snapshots__/batch-test.js.snap
@@ -23,6 +23,7 @@ Array [
         "Content-Type": "application/json",
       },
       "method": "POST",
+      "signal": AbortSignal {},
     },
   ],
   Array [
@@ -34,6 +35,7 @@ Array [
         "Content-Type": "application/json",
       },
       "method": "POST",
+      "signal": AbortSignal {},
     },
   ],
 ]
@@ -136,6 +138,7 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
+  "signal": AbortSignal {},
 }
 `;
 

--- a/src/middlewares/__tests__/__snapshots__/logger-test.js.snap
+++ b/src/middlewares/__tests__/__snapshots__/logger-test.js.snap
@@ -13,6 +13,7 @@ Array [
           "Content-Type": "application/json",
         },
         "method": "POST",
+        "signal": AbortSignal {},
       },
       "id": "MyRequest",
       "operation": Object {

--- a/src/middlewares/__tests__/__snapshots__/perf-test.js.snap
+++ b/src/middlewares/__tests__/__snapshots__/perf-test.js.snap
@@ -10,6 +10,7 @@ RelayRequest {
       "Content-Type": "application/json",
     },
     "method": "POST",
+    "signal": AbortSignal {},
   },
   "id": "MyRequest",
   "operation": Object {

--- a/src/middlewares/__tests__/__snapshots__/retry-test.js.snap
+++ b/src/middlewares/__tests__/__snapshots__/retry-test.js.snap
@@ -11,6 +11,7 @@ Array [
         "Content-Type": "application/json",
       },
       "method": "POST",
+      "signal": AbortSignal {},
     },
   ],
   Array [
@@ -22,6 +23,7 @@ Array [
         "Content-Type": "application/json",
       },
       "method": "POST",
+      "signal": AbortSignal {},
     },
   ],
   Array [
@@ -33,6 +35,7 @@ Array [
         "Content-Type": "application/json",
       },
       "method": "POST",
+      "signal": AbortSignal {},
     },
   ],
 ]
@@ -49,6 +52,7 @@ Array [
         "Content-Type": "application/json",
       },
       "method": "POST",
+      "signal": AbortSignal {},
     },
   ],
   Array [
@@ -60,6 +64,7 @@ Array [
         "Content-Type": "application/json",
       },
       "method": "POST",
+      "signal": AbortSignal {},
     },
   ],
   Array [
@@ -71,6 +76,7 @@ Array [
         "Content-Type": "application/json",
       },
       "method": "POST",
+      "signal": AbortSignal {},
     },
   ],
 ]

--- a/src/middlewares/__tests__/__snapshots__/url-test.js.snap
+++ b/src/middlewares/__tests__/__snapshots__/url-test.js.snap
@@ -8,6 +8,7 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "GET",
+  "signal": AbortSignal {},
   "url": "/get_url",
 }
 `;
@@ -20,6 +21,7 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
+  "signal": AbortSignal {},
   "url": "/some_url",
 }
 `;
@@ -32,6 +34,7 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
+  "signal": AbortSignal {},
   "url": "/thunk_url",
 }
 `;
@@ -44,6 +47,7 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
+  "signal": AbortSignal {},
   "url": "/thunk_url_promise",
 }
 `;


### PR DESCRIPTION
Returning an "observable" instead of a promise enables support for cancelling requests, `commitMutation` for example, by calling `dispose()` on the returned object.
Also added a message to logger for when a request is cancelled.
Not sure if this also solves #40, I do not have a test for that.
Uses AbortController for fetch cancellation which is supported in most modern browsers.

Note: Depending on when the request is cancelled the server might still apply the changes of a mutation.