### PR TITLE
Check for `window`

### DIFF
--- a/src/RelayRequest.js
+++ b/src/RelayRequest.js
@@ -37,7 +37,7 @@ export default class RelayRequest {
       body: this.prepareBody(),
     };
 
-    this.controller = window.AbortController ? new window.AbortController() : null;
+    this.controller = (typeof window !== 'undefined' && window.AbortController) ? new window.AbortController() : null;
     if (this.controller) fetchOpts.signal = this.controller.signal;
 
     this.fetchOpts = fetchOpts;


### PR DESCRIPTION
This fixes using the library in non-browser environments. Not sure why this is on `window` -- should probably also check `global`, similar to `getFormDataInterface`?

