### PR TITLE
Batch request list as array & check duplicates comparing body

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ Internally batching in `NetworkLayer` prepare list of queries `[ {query, variabl
 
 As of v4.0.0, the batch middleware utilizing request IDs in queries and corresponding results has been renamed `legacyBatchMiddleware`. The legacy middleware included a request ID with each query included in the batch and expected the server to return each result with the corresponding request ID. The new `batchMiddleware` simply expects results be returned in the same order as the batched queries.
 
+**NOTE:** `legacyBatchMiddleware` does not correctly deduplicate queries when batched because query variables may be ignored in a comparison. This means that two identical queries with _different_ variables will show the same results due to a bug ([#31](https://github.com/relay-tools/react-relay-network-modern/issues/31)). It is highly encouraged to use the new order-based `batchMiddleware`, which still deduplicates queries, but includes the variables in the comparison.
+
 ## Contribute
 
 I actively welcome pull requests with code and doc fixes.

--- a/README.md
+++ b/README.md
@@ -75,67 +75,67 @@ import { RelayNetworkLayer } from 'react-relay-network-modern/es';
 
 ### Built-in middlewares
 
-* **your custom inline middleware** - [see example](https://github.com/relay-tools/react-relay-network-modern#example-of-injecting-networklayer-with-middlewares-on-the-client-side) below where added `credentials` and `headers` to the `fetch` method.
-  * `next => req => { /* your modification of 'req' object */ return next(req); }`
-* **urlMiddleware** - for manipulating fetch `url` on fly via thunk.
-  * `url` - string for single request. Can be Promise or function(req). (default: `/graphql`).
-  * `method` - string, for request method type (default: `POST`)
-  * headers - Object with headers for fetch. Can be Promise or function(req).
-  * credentials - string, setting for fetch method, eg. 'same-origin' (default: empty).
-  * also you may provide `mode`, `cache`, `redirect` options for fetch method, for details see [fetch spec](https://fetch.spec.whatwg.org/#requests).
-* **cacheMiddleware** - for caching same queries you may use this middleware. It will skip (do not cache) mutations and FormData requests.
-  * `size` - max number of request in cache, least-recently _updated_ entries purged first (default: `100`).
-  * `ttl` - number in milliseconds, how long records stay valid in cache (default: `900000`, 15 minutes).
-  * `onInit` - function(cache) which will be called once when cache is created. As first argument you receive `QueryResponseCache` instance from `relay-runtime`.
-  * `allowMutations` - allow to cache Mutation requests (default: `false`)
-  * `allowFormData` - allow to cache FormData requests (default: `false`)
-  * `clearOnMutation` - clear the cache on any Mutation (default: `false`)
-  * `cacheErrors` - cache responses with errors (default: `false`)
-* **authMiddleware** - for adding auth token, and refreshing it if gets 401 response from server.
-  * `token` - string which returns token. Can be function(req) or Promise. If function is provided, then it will be called for every request (so you may change tokens on fly).
-  * `tokenRefreshPromise`: - function(req, res) which must return promise or regular value with a new token. This function is called when server returns 401 status code. After receiving a new token, middleware re-run query to the server seamlessly for Relay.
-  * `allowEmptyToken` - allow made a request without Authorization header if token is empty (default: `false`).
-  * `prefix` - prefix before token (default: `'Bearer '`).
-  * `header` - name of the HTTP header to pass the token in (default: `'Authorization'`).
-  * If you use `auth` middleware with `retry`, `retry` must be used before `auth`. Eg. if token expired when retries apply, then `retry` can call `auth` middleware again.
-* **retryMiddleware** - for request retry if the initial request fails.
-  * `fetchTimeout` - number in milliseconds that defines in how much time will request timeout after it has been sent to the server again (default: `15000`). Or it may be a function `(attempt: number) => number` which returns a timeout in milliseconds (`attempt` starts from 0).
-  * `retryDelays` - array of millisecond that defines the values on which retries are based on (default: `[1000, 3000]`). Or it may be a function `(attempt: number) => number | false` which returns a timeout in milliseconds for retry or false for disabling retry (`attempt` starts from 0).
-  * `statusCodes` - array of response status codes which will fire up retryMiddleware. Or it may be a function `(statusCode: number, req, res) => boolean` which makes retry if returned true. (default: `status < 200 or status > 300`).
-  * `beforeRetry` - function(meta: { forceRetry: Function, abort: Function, delay: number, attempt: number, lastError: ?Error, req: RelayRequest }) called before every retry attempt. You get one argument with following properties:
-    * `forceRetry()` - for proceeding request immediately
-    * `abort(abortMsg: string)` - for aborting retry request. (Default abort message is: `"Aborted in beforeRetry() callback"`)
-    * `attempt` - number of the attemp (starts from 1)
-    * `delay` - number of milliseconds when next retry will be called
-    * `lastError` - will keep Error from previous request
-    * `req` - retriable Request object
-  * `allowMutations` - by default retries disabled for mutations, you may allow process retries for them passing `true`. (default: `false`)
-  * `allowFormData` - by default retries disabled for file Uploads, you may enable it passing `true` (default: `false`)
-  * `forceRetry` - deprecated, use `beforeRetry` instead (default: `false`).
-* **batchMiddleware** - gather some period of time relay-requests and sends it as one http-request. You server must support batch request, [how to setup your server](https://github.com/relay-tools/react-relay-network-modern#example-how-to-enable-batching)
-  * `batchUrl` - string. Url of the server endpoint for batch request execution. Can be function(requestMap) or Promise. (default: `/graphql/batch`)
-  * `batchTimeout` - integer in milliseconds, period of time for gathering multiple requests before sending them to the server. Will delay sending of the requests on specified in this option period of time, so be careful and keep this value small. (default: `0`)
-  * `maxBatchSize` - integer representing maximum size of request to be sent in a single batch. Once a request hits the provided size in length a new batch request is ran. Actual for hardcoded limit in 100kb per request in [express-graphql](https://github.com/graphql/express-graphql/blob/master/src/parseBody.js#L112) module. (default: `102400` characters, roughly 100kb for 1-byte characters or 200kb for 2-byte characters)
-  * `allowMutations` - by default batching disabled for mutations, you may enable it passing `true` (default: `false`)
-  * `method` - string, for request method type (default: `POST`)
-  * headers - Object with headers for fetch. Can be Promise or function(req).
-  * credentials - string, setting for fetch method, eg. 'same-origin' (default: empty).
-  * also you may provide `mode`, `cache`, `redirect` options for fetch method, for details see [fetch spec](https://fetch.spec.whatwg.org/#requests).
-* **loggerMiddleware** - for logging requests and responses.
-  * `logger` - log function (default: `console.log.bind(console, '[RELAY-NETWORK]')`)
-  * An example of req/res output in console: <img width="968" alt="screen shot 2017-11-19 at 23 05 19" src="https://user-images.githubusercontent.com/1946920/33159466-557517e0-d03d-11e7-9711-ebdfe6e789c8.png">
-* **perfMiddleware** - simple time measure for network request.
-  * `logger` - log function (default: `console.log.bind(console, '[RELAY-NETWORK]')`)
-* **errorMiddleware** - display `errors` data to console from graphql response. If you want see stackTrace for errors, you should provide `formatError` to `express-graphql` (see example below where `graphqlServer` accept `formatError` function).
-  * `logger` - log function (default: `console.error.bind(console)`)
-  * `prefix` - prefix message (default: `[RELAY-NETWORK] GRAPHQL SERVER ERROR:`)
-* **progressMiddleware** - enable onProgress callback for modern browsers with support for Stream API.
-  * `onProgress` - on progress callback function (`function(bytesCurrent: number, bytesTotal: number | null) => void`, total size will be null if size header is not set)
-  * `sizeHeader` - response header with total size of response (default: `Content-Length`, useful when `Transfer-Encoding: chunked` is set)
+- **your custom inline middleware** - [see example](https://github.com/relay-tools/react-relay-network-modern#example-of-injecting-networklayer-with-middlewares-on-the-client-side) below where added `credentials` and `headers` to the `fetch` method.
+  - `next => req => { /* your modification of 'req' object */ return next(req); }`
+- **urlMiddleware** - for manipulating fetch `url` on fly via thunk.
+  - `url` - string for single request. Can be Promise or function(req). (default: `/graphql`).
+  - `method` - string, for request method type (default: `POST`)
+  - headers - Object with headers for fetch. Can be Promise or function(req).
+  - credentials - string, setting for fetch method, eg. 'same-origin' (default: empty).
+  - also you may provide `mode`, `cache`, `redirect` options for fetch method, for details see [fetch spec](https://fetch.spec.whatwg.org/#requests).
+- **cacheMiddleware** - for caching same queries you may use this middleware. It will skip (do not cache) mutations and FormData requests.
+  - `size` - max number of request in cache, least-recently _updated_ entries purged first (default: `100`).
+  - `ttl` - number in milliseconds, how long records stay valid in cache (default: `900000`, 15 minutes).
+  - `onInit` - function(cache) which will be called once when cache is created. As first argument you receive `QueryResponseCache` instance from `relay-runtime`.
+  - `allowMutations` - allow to cache Mutation requests (default: `false`)
+  - `allowFormData` - allow to cache FormData requests (default: `false`)
+  - `clearOnMutation` - clear the cache on any Mutation (default: `false`)
+  - `cacheErrors` - cache responses with errors (default: `false`)
+- **authMiddleware** - for adding auth token, and refreshing it if gets 401 response from server.
+  - `token` - string which returns token. Can be function(req) or Promise. If function is provided, then it will be called for every request (so you may change tokens on fly).
+  - `tokenRefreshPromise`: - function(req, res) which must return promise or regular value with a new token. This function is called when server returns 401 status code. After receiving a new token, middleware re-run query to the server seamlessly for Relay.
+  - `allowEmptyToken` - allow made a request without Authorization header if token is empty (default: `false`).
+  - `prefix` - prefix before token (default: `'Bearer '`).
+  - `header` - name of the HTTP header to pass the token in (default: `'Authorization'`).
+  - If you use `auth` middleware with `retry`, `retry` must be used before `auth`. Eg. if token expired when retries apply, then `retry` can call `auth` middleware again.
+- **retryMiddleware** - for request retry if the initial request fails.
+  - `fetchTimeout` - number in milliseconds that defines in how much time will request timeout after it has been sent to the server again (default: `15000`). Or it may be a function `(attempt: number) => number` which returns a timeout in milliseconds (`attempt` starts from 0).
+  - `retryDelays` - array of millisecond that defines the values on which retries are based on (default: `[1000, 3000]`). Or it may be a function `(attempt: number) => number | false` which returns a timeout in milliseconds for retry or false for disabling retry (`attempt` starts from 0).
+  - `statusCodes` - array of response status codes which will fire up retryMiddleware. Or it may be a function `(statusCode: number, req, res) => boolean` which makes retry if returned true. (default: `status < 200 or status > 300`).
+  - `beforeRetry` - function(meta: { forceRetry: Function, abort: Function, delay: number, attempt: number, lastError: ?Error, req: RelayRequest }) called before every retry attempt. You get one argument with following properties:
+    - `forceRetry()` - for proceeding request immediately
+    - `abort(abortMsg: string)` - for aborting retry request. (Default abort message is: `"Aborted in beforeRetry() callback"`)
+    - `attempt` - number of the attemp (starts from 1)
+    - `delay` - number of milliseconds when next retry will be called
+    - `lastError` - will keep Error from previous request
+    - `req` - retriable Request object
+  - `allowMutations` - by default retries disabled for mutations, you may allow process retries for them passing `true`. (default: `false`)
+  - `allowFormData` - by default retries disabled for file Uploads, you may enable it passing `true` (default: `false`)
+  - `forceRetry` - deprecated, use `beforeRetry` instead (default: `false`).
+- **batchMiddleware** - gather some period of time relay-requests and sends it as one http-request. You server must support batch request, [how to setup your server](https://github.com/relay-tools/react-relay-network-modern#example-how-to-enable-batching)
+  - `batchUrl` - string. Url of the server endpoint for batch request execution. Can be function(requestList) or Promise. (default: `/graphql/batch`)
+  - `batchTimeout` - integer in milliseconds, period of time for gathering multiple requests before sending them to the server. Will delay sending of the requests on specified in this option period of time, so be careful and keep this value small. (default: `0`)
+  - `maxBatchSize` - integer representing maximum size of request to be sent in a single batch. Once a request hits the provided size in length a new batch request is ran. Actual for hardcoded limit in 100kb per request in [express-graphql](https://github.com/graphql/express-graphql/blob/master/src/parseBody.js#L112) module. (default: `102400` characters, roughly 100kb for 1-byte characters or 200kb for 2-byte characters)
+  - `allowMutations` - by default batching disabled for mutations, you may enable it passing `true` (default: `false`)
+  - `method` - string, for request method type (default: `POST`)
+  - headers - Object with headers for fetch. Can be Promise or function(req).
+  - credentials - string, setting for fetch method, eg. 'same-origin' (default: empty).
+  - also you may provide `mode`, `cache`, `redirect` options for fetch method, for details see [fetch spec](https://fetch.spec.whatwg.org/#requests).
+- **loggerMiddleware** - for logging requests and responses.
+  - `logger` - log function (default: `console.log.bind(console, '[RELAY-NETWORK]')`)
+  - An example of req/res output in console: <img width="968" alt="screen shot 2017-11-19 at 23 05 19" src="https://user-images.githubusercontent.com/1946920/33159466-557517e0-d03d-11e7-9711-ebdfe6e789c8.png">
+- **perfMiddleware** - simple time measure for network request.
+  - `logger` - log function (default: `console.log.bind(console, '[RELAY-NETWORK]')`)
+- **errorMiddleware** - display `errors` data to console from graphql response. If you want see stackTrace for errors, you should provide `formatError` to `express-graphql` (see example below where `graphqlServer` accept `formatError` function).
+  - `logger` - log function (default: `console.error.bind(console)`)
+  - `prefix` - prefix message (default: `[RELAY-NETWORK] GRAPHQL SERVER ERROR:`)
+- **progressMiddleware** - enable onProgress callback for modern browsers with support for Stream API.
+  - `onProgress` - on progress callback function (`function(bytesCurrent: number, bytesTotal: number | null) => void`, total size will be null if size header is not set)
+  - `sizeHeader` - response header with total size of response (default: `Content-Length`, useful when `Transfer-Encoding: chunked` is set)
 
 ### Standalone package middlewares
 
-* [**react-relay-network-modern-ssr**](https://github.com/relay-tools/react-relay-network-modern-ssr) - client/server middleware for server-side rendering (SSR). On server side it makes requests directly via `graphql-js` and your `schema`, cache payloads and serialize them for putting to HTML. On client side it loads provided payloads and renders them in sync mode without visible flashes and loaders.
+- [**react-relay-network-modern-ssr**](https://github.com/relay-tools/react-relay-network-modern-ssr) - client/server middleware for server-side rendering (SSR). On server side it makes requests directly via `graphql-js` and your `schema`, cache payloads and serialize them for putting to HTML. On client side it loads provided payloads and renders them in sync mode without visible flashes and loaders.
 
 ### Example of injecting NetworkLayer with middlewares on the **client side**
 
@@ -161,10 +161,10 @@ const network = new RelayNetworkLayer(
       ttl: 900000, // 15 minutes
     }),
     urlMiddleware({
-      url: req => Promise.resolve('/graphql'),
+      url: (req) => Promise.resolve('/graphql'),
     }),
     batchMiddleware({
-      batchUrl: requestMap => Promise.resolve('/graphql/batch'),
+      batchUrl: (requestList) => Promise.resolve('/graphql/batch'),
       batchTimeout: 10,
     }),
     __DEV__ ? loggerMiddleware() : null,
@@ -172,7 +172,7 @@ const network = new RelayNetworkLayer(
     __DEV__ ? perfMiddleware() : null,
     retryMiddleware({
       fetchTimeout: 15000,
-      retryDelays: attempt => Math.pow(2, attempt + 4) * 100, // or simple array [3200, 6400, 12800, 25600, 51200, 102400, 204800, 409600],
+      retryDelays: (attempt) => Math.pow(2, attempt + 4) * 100, // or simple array [3200, 6400, 12800, 25600, 51200, 102400, 204800, 409600],
       beforeRetry: ({ forceRetry, abort, delay, attempt, lastError, req }) => {
         if (attempt > 10) abort();
         window.forceRelayRetry = forceRetry;
@@ -182,16 +182,16 @@ const network = new RelayNetworkLayer(
     }),
     authMiddleware({
       token: () => store.get('jwt'),
-      tokenRefreshPromise: req => {
+      tokenRefreshPromise: (req) => {
         console.log('[client.js] resolve token refresh', req);
         return fetch('/jwt/refresh')
-          .then(res => res.json())
-          .then(json => {
+          .then((res) => res.json())
+          .then((json) => {
             const token = json.token;
             store.set('jwt', token);
             return token;
           })
-          .catch(err => console.log('[client.js] ERROR can not refresh token', err));
+          .catch((err) => console.log('[client.js] ERROR can not refresh token', err));
       },
     }),
     progressMiddleware({
@@ -201,7 +201,7 @@ const network = new RelayNetworkLayer(
     }),
 
     // example of the custom inline middleware
-    next => async req => {
+    (next) => async (req) => {
       req.fetchOpts.method = 'GET'; // change default POST request method to GET
       req.fetchOpts.headers['X-Request-ID'] = uuid.v4(); // add `X-Request-ID` to request headers
       req.fetchOpts.credentials = 'same-origin'; // allow to send cookies (sending credentials to same domains)
@@ -235,8 +235,8 @@ const network = new RelayNetworkLayer(middlewares, options);
 
 Available options:
 
-* **subscribeFn** - if you use subscriptions in your app, you may provide this function which will be passed to [RelayNetwork](https://github.com/facebook/relay/blob/master/packages/relay-runtime/network/RelayNetwork.js).
-* **noThrow** - **EXPERIMENTAL (May be deprecated in the future)** set true to not throw when an error response is given by the server, and to instead handle errors in your app code.
+- **subscribeFn** - if you use subscriptions in your app, you may provide this function which will be passed to [RelayNetwork](https://github.com/facebook/relay/blob/master/packages/relay-runtime/network/RelayNetwork.js).
+- **noThrow** - **EXPERIMENTAL (May be deprecated in the future)** set true to not throw when an error response is given by the server, and to instead handle errors in your app code.
 
 ## Server-side rendering (SSR)
 
@@ -250,9 +250,9 @@ Middleware that needs access to the raw response body from fetch (before it has 
 
 Middlewares have 3 phases:
 
-* `setup phase`, which runs only once, when middleware added to the NetworkLayer
-* `capturing phase`, when you may change request object, and pass it down via `next(req)`
-* `bubbling phase`, when you may change response promise, made re-request or pass it up unchanged
+- `setup phase`, which runs only once, when middleware added to the NetworkLayer
+- `capturing phase`, when you may change request object, and pass it down via `next(req)`
+- `bubbling phase`, when you may change response promise, made re-request or pass it up unchanged
 
 Basic skeleton of middleware:
 
@@ -260,7 +260,7 @@ Basic skeleton of middleware:
 export default function skeletonMiddleware(opts = {}) {
   // [SETUP PHASE]: here you can process `opts`, when you create Middleware
 
-  return next => async req => {
+  return (next) => async (req) => {
     // [CAPTURING PHASE]: here you can change `req` object, before it will pass to following middlewares.
     // ...some code which modify `req`
 
@@ -276,15 +276,15 @@ export default function skeletonMiddleware(opts = {}) {
 
 Middlewares use LIFO (last in, first out) stack. Or simply put - use `compose` function. So if you pass such middlewares [M1(opts), M2(opts)] to NetworkLayer it will be work such way:
 
-* call setup phase of `M1` with its opts
-* call setup phase of `M2` with its opts
-* for each request
-* call capture phase of `M1`
-* call capture phase of `M2`
-* call `fetch` method
-* call bubbling phase of `M2`
-* call bubbling phase of `M1`
-* chain to `resPromise.then(res => res.json())` and pass this promise for resolving/rejecting Relay requests.
+- call setup phase of `M1` with its opts
+- call setup phase of `M2` with its opts
+- for each request
+- call capture phase of `M1`
+- call capture phase of `M2`
+- call `fetch` method
+- call bubbling phase of `M2`
+- call bubbling phase of `M1`
+- chain to `resPromise.then(res => res.json())` and pass this promise for resolving/rejecting Relay requests.
 
 ## Batching several requests into one
 
@@ -313,7 +313,7 @@ const server = express();
 // setup standart `graphqlHTTP` express-middleware
 const graphqlServer = graphqlHTTP({
   schema: myGraphqlSchema,
-  formatError: error => ({
+  formatError: (error) => ({
     // better errors for development. `stack` used in `gqErrors` middleware
     message: error.message,
     stack: process.env.NODE_ENV === 'development' ? error.stack.split('\n') : null,

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "form-data": "^2.3.3",
     "jest": "^24.7.0",
     "prettier": "^1.16.4",
-    "relay-runtime": "^3.0.0",
+    "relay-runtime": "^4.0.0",
     "rimraf": "^2.6.3",
     "semantic-release": "^15.13.3",
     "tslint": "^5.15.0",

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 import RelayNetworkLayer from './RelayNetworkLayer';
 import batchMiddleware, { RRNLBatchMiddlewareError } from './middlewares/batch';
+import legacyBatchMiddleware from './middlewares/legacyBatch';
 import retryMiddleware, { RRNLRetryMiddlewareError } from './middlewares/retry';
 import urlMiddleware from './middlewares/url';
 import authMiddleware, { RRNLAuthMiddlewareError } from './middlewares/auth';
@@ -23,6 +24,7 @@ export {
   RelayNetworkLayerRequestBatch,
   RelayNetworkLayerResponse,
   batchMiddleware,
+  legacyBatchMiddleware,
   retryMiddleware,
   urlMiddleware,
   authMiddleware,

--- a/src/middlewares/__tests__/__snapshots__/batch-test.js.snap
+++ b/src/middlewares/__tests__/__snapshots__/batch-test.js.snap
@@ -154,18 +154,6 @@ Object {
 }
 `;
 
-exports[`middlewares/batch should make a successfully batch request with duplicate request ids 1`] = `
-Object {
-  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
-  "headers": Object {
-    "Accept": "*/*",
-    "Content-Type": "application/json",
-  },
-  "method": "POST",
-  "url": "/graphql/batch",
-}
-`;
-
 exports[`middlewares/batch should make a successfully batch request with duplicate request payloads 1`] = `
 Object {
   "body": "[{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"duplicate\\",\\"variables\\":{\\"duplicate\\":true}}]",
@@ -178,33 +166,9 @@ Object {
 }
 `;
 
-exports[`middlewares/batch should reject if server does not return response for duplicate request ids 1`] = `
-Object {
-  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"3\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
-  "headers": Object {
-    "Accept": "*/*",
-    "Content-Type": "application/json",
-  },
-  "method": "POST",
-  "url": "/graphql/batch",
-}
-`;
-
 exports[`middlewares/batch should reject if server does not return response for duplicate request payloads 1`] = `
 Object {
   "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"3\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
-  "headers": Object {
-    "Accept": "*/*",
-    "Content-Type": "application/json",
-  },
-  "method": "POST",
-  "url": "/graphql/batch",
-}
-`;
-
-exports[`middlewares/batch should reject if server does not return response for request 1`] = `
-Object {
-  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}}}]",
   "headers": Object {
     "Accept": "*/*",
     "Content-Type": "application/json",

--- a/src/middlewares/__tests__/__snapshots__/batch-test.js.snap
+++ b/src/middlewares/__tests__/__snapshots__/batch-test.js.snap
@@ -43,7 +43,7 @@ Array [
 
 exports[`middlewares/batch option \`batchTimeout\` should gather different requests into one batch request 1`] = `
 Object {
-  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"3\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
+  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"3\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
   "headers": Object {
     "Accept": "*/*",
     "Content-Type": "application/json",
@@ -166,7 +166,31 @@ Object {
 }
 `;
 
+exports[`middlewares/batch should make a successfully batch request with duplicate request payloads 1`] = `
+Object {
+  "body": "[{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"duplicate\\",\\"variables\\":{\\"duplicate\\":true}}]",
+  "headers": Object {
+    "Accept": "*/*",
+    "Content-Type": "application/json",
+  },
+  "method": "POST",
+  "url": "/graphql/batch",
+}
+`;
+
 exports[`middlewares/batch should reject if server does not return response for duplicate request ids 1`] = `
+Object {
+  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"3\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
+  "headers": Object {
+    "Accept": "*/*",
+    "Content-Type": "application/json",
+  },
+  "method": "POST",
+  "url": "/graphql/batch",
+}
+`;
+
+exports[`middlewares/batch should reject if server does not return response for duplicate request payloads 1`] = `
 Object {
   "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"3\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
   "headers": Object {
@@ -180,7 +204,7 @@ Object {
 
 exports[`middlewares/batch should reject if server does not return response for request 1`] = `
 Object {
-  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
+  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}}}]",
   "headers": Object {
     "Accept": "*/*",
     "Content-Type": "application/json",

--- a/src/middlewares/__tests__/__snapshots__/legacyBatch-test.js.snap
+++ b/src/middlewares/__tests__/__snapshots__/legacyBatch-test.js.snap
@@ -1,0 +1,191 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`middlewares/legacyBatch option \`allowMutations\` should batch mutations if \`allowMutations=true\` 1`] = `
+Object {
+  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"mutation {}\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"mutation {}\\",\\"variables\\":{}}]",
+  "headers": Object {
+    "Accept": "*/*",
+    "Content-Type": "application/json",
+  },
+  "method": "POST",
+  "url": "/graphql/batch",
+}
+`;
+
+exports[`middlewares/legacyBatch option \`allowMutations\` should not batch mutations by default 1`] = `
+Array [
+  Array [
+    "/graphql",
+    Object {
+      "body": "{\\"id\\":\\"1\\",\\"query\\":\\"mutation {}\\",\\"variables\\":{}}",
+      "headers": Object {
+        "Accept": "*/*",
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "signal": AbortSignal {},
+    },
+  ],
+  Array [
+    "/graphql",
+    Object {
+      "body": "{\\"id\\":\\"1\\",\\"query\\":\\"mutation {}\\",\\"variables\\":{}}",
+      "headers": Object {
+        "Accept": "*/*",
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "signal": AbortSignal {},
+    },
+  ],
+]
+`;
+
+exports[`middlewares/legacyBatch option \`batchTimeout\` should gather different requests into one batch request 1`] = `
+Object {
+  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"3\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
+  "headers": Object {
+    "Accept": "*/*",
+    "Content-Type": "application/json",
+  },
+  "method": "POST",
+  "url": "/graphql/batch",
+}
+`;
+
+exports[`middlewares/legacyBatch option \`batchTimeout\` should gather different requests into two batch request 1`] = `
+Array [
+  Array [
+    "/graphql/batch",
+    Object {
+      "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"4\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
+      "headers": Object {
+        "Accept": "*/*",
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "url": "/graphql/batch",
+    },
+  ],
+  Array [
+    "/graphql/batch",
+    Object {
+      "body": "[{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"3\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
+      "headers": Object {
+        "Accept": "*/*",
+        "Content-Type": "application/json",
+      },
+      "method": "POST",
+      "url": "/graphql/batch",
+    },
+  ],
+]
+`;
+
+exports[`middlewares/legacyBatch should handle network failure 1`] = `
+Object {
+  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
+  "headers": Object {
+    "Accept": "*/*",
+    "Content-Type": "application/json",
+  },
+  "method": "POST",
+  "url": "/graphql/batch",
+}
+`;
+
+exports[`middlewares/legacyBatch should handle responses without payload wrapper 1`] = `
+Object {
+  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
+  "headers": Object {
+    "Accept": "*/*",
+    "Content-Type": "application/json",
+  },
+  "method": "POST",
+  "url": "/graphql/batch",
+}
+`;
+
+exports[`middlewares/legacyBatch should handle server errors for all requests 1`] = `
+Object {
+  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"3\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
+  "headers": Object {
+    "Accept": "*/*",
+    "Content-Type": "application/json",
+  },
+  "method": "POST",
+  "url": "/graphql/batch",
+}
+`;
+
+exports[`middlewares/legacyBatch should handle server errors for one request 1`] = `
+Object {
+  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
+  "headers": Object {
+    "Accept": "*/*",
+    "Content-Type": "application/json",
+  },
+  "method": "POST",
+  "url": "/graphql/batch",
+}
+`;
+
+exports[`middlewares/legacyBatch should make a successfull single request 1`] = `
+Object {
+  "body": "{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}}",
+  "headers": Object {
+    "Accept": "*/*",
+    "Content-Type": "application/json",
+  },
+  "method": "POST",
+  "signal": AbortSignal {},
+}
+`;
+
+exports[`middlewares/legacyBatch should make a successfully batch request 1`] = `
+Object {
+  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
+  "headers": Object {
+    "Accept": "*/*",
+    "Content-Type": "application/json",
+  },
+  "method": "POST",
+  "url": "/graphql/batch",
+}
+`;
+
+exports[`middlewares/legacyBatch should make a successfully batch request with duplicate request ids 1`] = `
+Object {
+  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
+  "headers": Object {
+    "Accept": "*/*",
+    "Content-Type": "application/json",
+  },
+  "method": "POST",
+  "url": "/graphql/batch",
+}
+`;
+
+exports[`middlewares/legacyBatch should reject if server does not return response for duplicate request ids 1`] = `
+Object {
+  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"3\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
+  "headers": Object {
+    "Accept": "*/*",
+    "Content-Type": "application/json",
+  },
+  "method": "POST",
+  "url": "/graphql/batch",
+}
+`;
+
+exports[`middlewares/legacyBatch should reject if server does not return response for request 1`] = `
+Object {
+  "body": "[{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}},{\\"id\\":\\"2\\",\\"query\\":\\"\\",\\"variables\\":{}}]",
+  "headers": Object {
+    "Accept": "*/*",
+    "Content-Type": "application/json",
+  },
+  "method": "POST",
+  "url": "/graphql/batch",
+}
+`;

--- a/src/middlewares/__tests__/batch-test.js
+++ b/src/middlewares/__tests__/batch-test.js
@@ -70,32 +70,6 @@ describe('middlewares/batch', () => {
     expect(fetchMock.lastOptions()).toMatchSnapshot();
   });
 
-  it('should reject if server does not return response for request', async () => {
-    fetchMock.mock({
-      matcher: '/graphql/batch',
-      response: {
-        status: 200,
-        body: [{ data: { ok: 1 } }],
-      },
-      method: 'POST',
-    });
-
-    const rnl = new RelayNetworkLayer([batchMiddleware()]);
-    const req1 = mockReq(1);
-    const req2 = mockReq(2);
-
-    // prettier-ignore
-    const [res1, res2] = await Promise.all([
-      req1.execute(rnl),
-      req2.execute(rnl).catch(e => e),
-    ])
-
-    expect(res1.data).toEqual({ ok: 1 });
-    expect(res2).toBeInstanceOf(Error);
-    expect(res2.toString()).toMatch('Server does not return response for request');
-    expect(fetchMock.lastOptions()).toMatchSnapshot();
-  });
-
   it('should reject if server does not return response for duplicate request payloads', async () => {
     fetchMock.mock({
       matcher: '/graphql/batch',

--- a/src/middlewares/__tests__/legacyBatch-test.js
+++ b/src/middlewares/__tests__/legacyBatch-test.js
@@ -1,0 +1,562 @@
+/* @flow */
+
+import fetchMock from 'fetch-mock'
+import FormData from 'form-data'
+import { RelayNetworkLayer, legacyBatchMiddleware } from '../..'
+import {
+  mockReq,
+  mockReqWithSize,
+  mockMutationReq,
+  mockReqWithFiles
+} from '../../__mocks__/mockReq'
+
+global.FormData = FormData
+
+describe('middlewares/legacyBatch', () => {
+  beforeEach(() => {
+    fetchMock.restore()
+  })
+
+  it('should make a successfull single request', async () => {
+    fetchMock.post('/graphql', { data: { ok: 1 } })
+    const rnl = new RelayNetworkLayer([legacyBatchMiddleware()])
+    const req = mockReq(1)
+    const res = await req.execute(rnl)
+    expect(res.data).toEqual({ ok: 1 })
+    expect(fetchMock.lastOptions()).toMatchSnapshot()
+  })
+
+  it('should make a successfully batch request', async () => {
+    fetchMock.mock({
+      matcher: '/graphql/batch',
+      response: {
+        status: 200,
+        body: [{ id: 1, data: { ok: 1 } }, { id: 2, data: { ok: 2 } }]
+      },
+      method: 'POST'
+    })
+    const rnl = new RelayNetworkLayer([legacyBatchMiddleware()])
+    const req1 = mockReq(1)
+    const req2 = mockReq(2)
+    const [res1, res2] = await Promise.all([req1.execute(rnl), req2.execute(rnl)])
+    expect(res1.data).toEqual({ ok: 1 })
+    expect(res2.data).toEqual({ ok: 2 })
+    expect(fetchMock.lastOptions()).toMatchSnapshot()
+  })
+
+  it('should make a successfully batch request with duplicate request ids', async () => {
+    fetchMock.mock({
+      matcher: '/graphql/batch',
+      response: {
+        status: 200,
+        body: [{ id: 1, data: { ok: 1 } }, { id: 2, data: { ok: 2 } }]
+      },
+      method: 'POST'
+    })
+    const rnl = new RelayNetworkLayer([legacyBatchMiddleware()])
+    const req1 = mockReq(1)
+    const req2 = mockReq(2)
+    const req3 = mockReq(2)
+
+    const [res1, res2, res3] = await Promise.all([
+      req1.execute(rnl),
+      req2.execute(rnl),
+      req3.execute(rnl)
+    ])
+
+    expect(res1.data).toEqual({ ok: 1 })
+    expect(res2.data).toEqual({ ok: 2 })
+    expect(res3.data).toEqual({ ok: 2 })
+    expect(fetchMock.lastOptions()).toMatchSnapshot()
+  })
+
+  it('should reject if server does not return response for request', async () => {
+    fetchMock.mock({
+      matcher: '/graphql/batch',
+      response: {
+        status: 200,
+        body: [{ data: {} }, { id: 2, data: { ok: 2 } }]
+      },
+      method: 'POST'
+    })
+
+    const rnl = new RelayNetworkLayer([legacyBatchMiddleware()])
+    const req1 = mockReq(1)
+    const req2 = mockReq(2)
+
+    // prettier-ignore
+    const [res1, res2] = await Promise.all([
+      req1.execute(rnl).catch(e => e),
+      req2.execute(rnl)
+    ])
+
+    expect(res1).toBeInstanceOf(Error)
+    expect(res1.toString()).toMatch('Server does not return response for request')
+    expect(res2.data).toEqual({ ok: 2 })
+    expect(fetchMock.lastOptions()).toMatchSnapshot()
+  })
+
+  it('should reject if server does not return response for duplicate request ids', async () => {
+    fetchMock.mock({
+      matcher: '/graphql/batch',
+      response: {
+        status: 200,
+        body: [{ data: {} }, { id: 2, data: { ok: 2 } }]
+      },
+      method: 'POST'
+    })
+
+    const rnl = new RelayNetworkLayer([legacyBatchMiddleware()])
+    const req1 = mockReq(1)
+    const req2 = mockReq(2)
+    const req3 = mockReq(3)
+    const [res1, res2, res3] = await Promise.all([
+      req1.execute(rnl).catch((e) => e),
+      req2.execute(rnl),
+      req3.execute(rnl).catch((e) => e)
+    ])
+
+    expect(res1).toBeInstanceOf(Error)
+    expect(res1.toString()).toMatch('Server does not return response for request')
+    expect(res2.data).toEqual({ ok: 2 })
+    expect(res3).toBeInstanceOf(Error)
+    expect(res3.toString()).toMatch('Server does not return response for request')
+    expect(fetchMock.lastOptions()).toMatchSnapshot()
+  })
+
+  it('should handle network failure', async () => {
+    fetchMock.mock({
+      matcher: '/graphql/batch',
+      response: {
+        throws: new Error('Network connection error')
+      },
+      method: 'POST'
+    })
+
+    const rnl = new RelayNetworkLayer([legacyBatchMiddleware()])
+    const req1 = mockReq(1)
+    const req2 = mockReq(2)
+    const [res1, res2] = await Promise.all([
+      req1.execute(rnl).catch((e) => e),
+      req2.execute(rnl).catch((e) => e)
+    ])
+
+    expect(res1).toBeInstanceOf(Error)
+    expect(res1.toString()).toMatch('Network connection error')
+    expect(res2).toBeInstanceOf(Error)
+    expect(res2.toString()).toMatch('Network connection error')
+    expect(fetchMock.lastOptions()).toMatchSnapshot()
+  })
+
+  it('should handle server errors for one request', async () => {
+    fetchMock.mock({
+      matcher: '/graphql/batch',
+      response: {
+        status: 200,
+        body: [
+          {
+            id: 1,
+            payload: {
+              errors: [{ location: 1, message: 'major error' }]
+            }
+          },
+          { id: 2, payload: { data: { ok: 2 } } }
+        ]
+      },
+      method: 'POST'
+    })
+
+    const rnl = new RelayNetworkLayer([legacyBatchMiddleware()])
+    const req1 = mockReq(1)
+    const req2 = mockReq(2)
+    // prettier-ignore
+    const [res1, res2] = await Promise.all([
+      req1.execute(rnl).catch(e => e),
+      req2.execute(rnl)
+    ])
+
+    expect(res1).toBeInstanceOf(Error)
+    expect(res1.toString()).toMatch('major error')
+    expect(res2.data).toEqual({ ok: 2 })
+    expect(res2.errors).toBeUndefined()
+    expect(fetchMock.lastOptions()).toMatchSnapshot()
+  })
+
+  it('should handle server errors for all requests', async () => {
+    fetchMock.mock({
+      matcher: '/graphql/batch',
+      response: {
+        status: 200,
+        body: {
+          errors: [{ location: 1, message: 'major error' }]
+        }
+      },
+      method: 'POST'
+    })
+
+    const rnl = new RelayNetworkLayer([legacyBatchMiddleware()])
+    const req1 = mockReq(1)
+    const req2 = mockReq(2)
+    const req3 = mockReq(3)
+
+    const [res1, res2, res3] = await Promise.all([
+      req1.execute(rnl).catch((e) => e),
+      req2.execute(rnl).catch((e) => e),
+      req3.execute(rnl).catch((e) => e)
+    ])
+
+    expect(res1.toString()).toMatch('Wrong response')
+    expect(res2.toString()).toMatch('Wrong response')
+    expect(res3.toString()).toMatch('Wrong response')
+    expect(fetchMock.lastOptions()).toMatchSnapshot()
+  })
+
+  it('should handle responses without payload wrapper', async () => {
+    fetchMock.mock({
+      matcher: '/graphql/batch',
+      response: {
+        status: 200,
+        body: [
+          {
+            id: 1,
+            errors: [{ location: 1, message: 'major error' }]
+          },
+          { id: 2, data: { ok: 2 } }
+        ]
+      },
+      method: 'POST'
+    })
+
+    const rnl = new RelayNetworkLayer([legacyBatchMiddleware()])
+    const req1 = mockReq(1)
+    const req2 = mockReq(2)
+    // prettier-ignore
+    const [res1, res2] = await Promise.all([
+      req1.execute(rnl).catch(e => e),
+      req2.execute(rnl)
+    ])
+
+    expect(res1).toBeInstanceOf(Error)
+    expect(res1.toString()).toMatch('major error')
+    expect(res2.data).toEqual({ ok: 2 })
+    expect(res2.errors).toBeUndefined()
+    expect(fetchMock.lastOptions()).toMatchSnapshot()
+  })
+
+  describe('option `batchTimeout`', () => {
+    beforeEach(() => {
+      fetchMock.restore()
+    })
+
+    it('should gather different requests into one batch request', async () => {
+      fetchMock.mock({
+        matcher: '/graphql/batch',
+        response: {
+          status: 200,
+          body: [{ id: 1, data: {} }, { id: 2, data: {} }, { id: 3, data: {} }]
+        },
+        method: 'POST'
+      })
+
+      const rnl = new RelayNetworkLayer([legacyBatchMiddleware({ batchTimeout: 50 })])
+      mockReq(1).execute(rnl)
+      setTimeout(() => mockReq(2).execute(rnl), 30)
+
+      await mockReq(3).execute(rnl)
+
+      const reqs = fetchMock.calls('/graphql/batch')
+      expect(reqs).toHaveLength(1)
+      expect(fetchMock.lastOptions()).toMatchSnapshot()
+    })
+
+    it('should gather different requests into two batch request', async () => {
+      fetchMock.mock({
+        matcher: '/graphql/batch',
+        response: {
+          status: 200,
+          body: [
+            { id: 1, data: {} },
+            { id: 2, data: {} },
+            { id: 3, data: {} },
+            { id: 4, data: {} }
+          ]
+        },
+        method: 'POST'
+      })
+
+      const rnl = new RelayNetworkLayer([legacyBatchMiddleware({ batchTimeout: 100 })])
+      mockReq(1).execute(rnl)
+      setTimeout(() => mockReq(2).execute(rnl), 160)
+      setTimeout(() => mockReq(3).execute(rnl), 170)
+      mockReq(4).execute(rnl)
+
+      await new Promise((resolve, reject) => {
+        setTimeout(() => {
+          try {
+            const reqs = fetchMock.calls('/graphql/batch')
+            expect(reqs).toHaveLength(2)
+            expect(fetchMock.calls('/graphql/batch')).toMatchSnapshot()
+            resolve()
+          } catch (e) {
+            reject(e)
+          }
+        }, 300)
+      })
+    })
+  })
+
+  describe('option `maxBatchSize`', () => {
+    beforeEach(() => {
+      fetchMock.restore()
+    })
+
+    it('should split large batched requests into multiple requests', async () => {
+      fetchMock.mock({
+        matcher: '/graphql',
+        response: {
+          status: 200,
+          body: { id: 5, data: {} }
+        },
+        method: 'POST'
+      })
+
+      fetchMock.mock({
+        matcher: '/graphql/batch',
+        response: {
+          status: 200,
+          body: [
+            { id: 1, data: {} },
+            { id: 2, data: {} },
+            { id: 3, data: {} },
+            { id: 4, data: {} }
+          ]
+        },
+        method: 'POST'
+      })
+
+      const rnl = new RelayNetworkLayer([legacyBatchMiddleware({ maxBatchSize: 1024 * 10 })])
+      const req1 = mockReqWithSize(1, 1024 * 7)
+      const req2 = mockReqWithSize(2, 1024 * 2)
+      const req3 = mockReqWithSize(3, 1024 * 5)
+      const req4 = mockReqWithSize(4, 1024 * 4)
+      const req5 = mockReqWithSize(5, 1024 * 11)
+
+      await Promise.all([
+        req1.execute(rnl),
+        req2.execute(rnl),
+        req3.execute(rnl),
+        req4.execute(rnl),
+        req5.execute(rnl)
+      ])
+
+      const batchReqs = fetchMock.calls('/graphql/batch')
+      const singleReqs = fetchMock.calls('/graphql')
+      expect(batchReqs).toHaveLength(2)
+      expect(singleReqs).toHaveLength(1)
+    })
+  })
+
+  describe('option `allowMutations`', () => {
+    beforeEach(() => {
+      fetchMock.restore()
+    })
+
+    it('should not batch mutations by default', async () => {
+      fetchMock.mock({
+        matcher: '/graphql',
+        response: {
+          status: 200,
+          body: { id: 1, data: {} }
+        },
+        method: 'POST'
+      })
+
+      const rnl = new RelayNetworkLayer([legacyBatchMiddleware({ batchTimeout: 20 })])
+      mockMutationReq(1).execute(rnl)
+      await mockMutationReq(1).execute(rnl)
+      const singleReqs = fetchMock.calls('/graphql')
+      expect(singleReqs).toHaveLength(2)
+      expect(fetchMock.calls('/graphql')).toMatchSnapshot()
+    })
+
+    it('should not batch requests with FormData', async () => {
+      fetchMock.mock({
+        matcher: '/graphql',
+        response: {
+          status: 200,
+          body: { id: 1, data: {} }
+        },
+        method: 'POST'
+      })
+
+      const rnl = new RelayNetworkLayer([legacyBatchMiddleware({ batchTimeout: 20 })])
+      mockReqWithFiles(1).execute(rnl)
+      await mockReqWithFiles(1).execute(rnl)
+      const singleReqs = fetchMock.calls('/graphql')
+      expect(singleReqs).toHaveLength(2)
+    })
+
+    it('should batch mutations if `allowMutations=true`', async () => {
+      fetchMock.mock({
+        matcher: '/graphql/batch',
+        response: {
+          status: 200,
+          body: [{ id: 1, data: {} }, { id: 2, data: {} }]
+        },
+        method: 'POST'
+      })
+
+      const rnl = new RelayNetworkLayer([
+        legacyBatchMiddleware({ batchTimeout: 20, allowMutations: true })
+      ])
+      const req1 = mockMutationReq(1)
+      req1.execute(rnl)
+      const req2 = mockMutationReq(2)
+      await req2.execute(rnl)
+
+      const batchReqs = fetchMock.calls('/graphql/batch')
+      expect(batchReqs).toHaveLength(1)
+      expect(fetchMock.lastOptions()).toMatchSnapshot()
+    })
+
+    it('should not batch mutations with files if `allowMutations=true`', async () => {
+      fetchMock.mock({
+        matcher: '/graphql',
+        response: {
+          status: 200,
+          body: { id: 1, data: {} }
+        },
+        method: 'POST'
+      })
+
+      const rnl = new RelayNetworkLayer([
+        legacyBatchMiddleware({ batchTimeout: 20, allowMutations: true })
+      ])
+
+      const req1 = mockMutationReq(1, { files: { file1: 'data' } })
+      req1.execute(rnl)
+      const req2 = mockMutationReq(2, { files: { file1: 'data' } })
+      await req2.execute(rnl)
+
+      const singleReqs = fetchMock.calls('/graphql')
+      expect(singleReqs).toHaveLength(2)
+    })
+  })
+
+  it('should pass fetch options', async () => {
+    fetchMock.mock({
+      matcher: '/graphql/batch',
+      response: {
+        status: 200,
+        body: [{ id: 1, data: {} }, { id: 2, data: {} }]
+      },
+      method: 'POST'
+    })
+
+    const rnl = new RelayNetworkLayer([
+      legacyBatchMiddleware({
+        batchTimeout: 20,
+        credentials: 'include',
+        mode: 'cors',
+        cache: 'no-store',
+        redirect: 'follow'
+      })
+    ])
+    const req1 = mockReq(1)
+    req1.execute(rnl)
+    const req2 = mockReq(2)
+    await req2.execute(rnl)
+
+    const batchReqs = fetchMock.calls('/graphql/batch')
+    expect(batchReqs).toHaveLength(1)
+    expect(fetchMock.lastOptions()).toEqual(
+      expect.objectContaining({
+        credentials: 'include',
+        mode: 'cors',
+        cache: 'no-store',
+        redirect: 'follow'
+      })
+    )
+  })
+
+  describe('headers option', () => {
+    it('`headers` option as Object', async () => {
+      fetchMock.mock({
+        matcher: '/graphql/batch',
+        response: {
+          status: 200,
+          body: [{ id: 1, data: {} }, { id: 2, data: {} }]
+        },
+        method: 'POST'
+      })
+      const rnl = new RelayNetworkLayer([
+        legacyBatchMiddleware({
+          headers: {
+            'custom-header': '123'
+          }
+        })
+      ])
+      const req1 = mockReq(1)
+      const req2 = mockReq(2)
+      await Promise.all([req1.execute(rnl), req2.execute(rnl)])
+      expect(fetchMock.lastOptions().headers).toEqual(
+        expect.objectContaining({
+          'custom-header': '123'
+        })
+      )
+    })
+
+    it('`headers` option as thunk', async () => {
+      fetchMock.mock({
+        matcher: '/graphql/batch',
+        response: {
+          status: 200,
+          body: [{ id: 1, data: {} }, { id: 2, data: {} }]
+        },
+        method: 'POST'
+      })
+      const rnl = new RelayNetworkLayer([
+        legacyBatchMiddleware({
+          headers: () => ({
+            'thunk-header': '333'
+          })
+        })
+      ])
+      const req1 = mockReq(1)
+      const req2 = mockReq(2)
+      await Promise.all([req1.execute(rnl), req2.execute(rnl)])
+      expect(fetchMock.lastOptions().headers).toEqual(
+        expect.objectContaining({
+          'thunk-header': '333'
+        })
+      )
+    })
+
+    it('`headers` option as thunk with Promise', async () => {
+      fetchMock.mock({
+        matcher: '/graphql/batch',
+        response: {
+          status: 200,
+          body: [{ id: 1, data: {} }, { id: 2, data: {} }]
+        },
+        method: 'POST'
+      })
+      const rnl = new RelayNetworkLayer([
+        legacyBatchMiddleware({
+          headers: () =>
+            Promise.resolve({
+              'thunk-header': 'as promise'
+            })
+        })
+      ])
+      const req1 = mockReq(1)
+      const req2 = mockReq(2)
+      await Promise.all([req1.execute(rnl), req2.execute(rnl)])
+      expect(fetchMock.lastOptions().headers).toEqual(
+        expect.objectContaining({
+          'thunk-header': 'as promise'
+        })
+      )
+    })
+  })
+})

--- a/src/middlewares/batch.js
+++ b/src/middlewares/batch.js
@@ -153,8 +153,6 @@ function passThroughBatch(req: RelayRequest, next, opts) {
   });
 }
 
-function requestIdHashFor(req: RelayRequest) {}
-
 function prepareNewBatcher(next, opts): Batcher {
   const batcher: Batcher = {
     bodySize: 2, // account for '[]'

--- a/src/middlewares/batchLegacy.js
+++ b/src/middlewares/batchLegacy.js
@@ -1,0 +1,249 @@
+/* @flow */
+/* eslint-disable no-param-reassign */
+
+import { isFunction } from '../utils';
+import RelayRequestBatch from '../RelayRequestBatch';
+import RelayRequest from '../RelayRequest';
+import type RelayResponse from '../RelayResponse';
+import type { Middleware, FetchOpts } from '../definition';
+import RRNLError from '../RRNLError';
+
+// Max out at roughly 100kb (express-graphql imposed max)
+const DEFAULT_BATCH_SIZE = 102400;
+
+type Headers = { [name: string]: string };
+
+export type BatchMiddlewareOpts = {|
+  batchUrl?: string | Promise<string> | ((requestMap: BatchRequestMap) => string | Promise<string>),
+  batchTimeout?: number,
+  maxBatchSize?: number,
+  allowMutations?: boolean,
+  method?: 'POST' | 'GET',
+  headers?: Headers | Promise<Headers> | ((req: RelayRequestBatch) => Headers | Promise<Headers>),
+  // Avaliable request modes in fetch options. For details see https://fetch.spec.whatwg.org/#requests
+  credentials?: $PropertyType<FetchOpts, 'credentials'>,
+  mode?: $PropertyType<FetchOpts, 'mode'>,
+  cache?: $PropertyType<FetchOpts, 'cache'>,
+  redirect?: $PropertyType<FetchOpts, 'redirect'>,
+|};
+
+export type BatchRequestMap = {
+  [reqId: string]: RequestWrapper,
+};
+
+export type RequestWrapper = {|
+  req: RelayRequest,
+  completeOk: (res: Object) => void,
+  completeErr: (e: Error) => void,
+  done: boolean,
+  duplicates: Array<RequestWrapper>,
+|};
+
+type Batcher = {
+  bodySize: number,
+  requestMap: BatchRequestMap,
+  acceptRequests: boolean,
+};
+
+export class RRNLBatchMiddlewareError extends RRNLError {
+  constructor(msg: string) {
+    super(msg);
+    this.name = 'RRNLBatchMiddlewareError';
+  }
+}
+
+export default function batchMiddlewareLegacy(options?: BatchMiddlewareOpts): Middleware {
+  const opts = options || {};
+  const batchTimeout = opts.batchTimeout || 0; // 0 is the same as nextTick in nodeJS
+  const allowMutations = opts.allowMutations || false;
+  const batchUrl = opts.batchUrl || '/graphql/batch';
+  const maxBatchSize = opts.maxBatchSize || DEFAULT_BATCH_SIZE;
+  const singleton = {};
+
+  const fetchOpts = {};
+  if (opts.method) fetchOpts.method = opts.method;
+  if (opts.credentials) fetchOpts.credentials = opts.credentials;
+  if (opts.mode) fetchOpts.mode = opts.mode;
+  if (opts.cache) fetchOpts.cache = opts.cache;
+  if (opts.redirect) fetchOpts.redirect = opts.redirect;
+  if (opts.headers) fetchOpts.headersOrThunk = opts.headers;
+
+  return (next) => (req) => {
+    // do not batch mutations unless allowMutations = true
+    if (req.isMutation() && !allowMutations) {
+      return next(req);
+    }
+
+    if (!(req instanceof RelayRequest)) {
+      throw new RRNLBatchMiddlewareError(
+        'Relay batch middleware accepts only simple RelayRequest. Did you add batchMiddleware twice?'
+      );
+    }
+
+    // req with FormData can not be batched
+    if (req.isFormData()) {
+      return next(req);
+    }
+
+    return passThroughBatch(req, next, {
+      batchTimeout,
+      batchUrl,
+      singleton,
+      maxBatchSize,
+      fetchOpts,
+    });
+  };
+}
+
+function passThroughBatch(req: RelayRequest, next, opts) {
+  const { singleton } = opts;
+
+  const bodyLength = (req.fetchOpts.body: any).length;
+  if (!bodyLength) {
+    return next(req);
+  }
+
+  if (!singleton.batcher || !singleton.batcher.acceptRequests) {
+    singleton.batcher = prepareNewBatcher(next, opts);
+  }
+
+  if (singleton.batcher.bodySize + bodyLength + 1 > opts.maxBatchSize) {
+    singleton.batcher = prepareNewBatcher(next, opts);
+  }
+
+  // +1 accounts for tailing comma after joining
+  singleton.batcher.bodySize += bodyLength + 1;
+
+  // queue request
+  return new Promise((resolve, reject) => {
+    const relayReqId = req.getID();
+    const { requestMap } = singleton.batcher;
+
+    const requestWrapper: RequestWrapper = {
+      req,
+      completeOk: (res) => {
+        requestWrapper.done = true;
+        resolve(res);
+        requestWrapper.duplicates.forEach((r) => r.completeOk(res));
+      },
+      completeErr: (err) => {
+        requestWrapper.done = true;
+        reject(err);
+        requestWrapper.duplicates.forEach((r) => r.completeErr(err));
+      },
+      done: false,
+      duplicates: [],
+    };
+
+    if (requestMap[relayReqId]) {
+      /*
+        I've run into a scenario with Relay Classic where if you have 2 components
+        that make the exact same query, Relay will dedup the queries and reuse
+        the request ids but still make 2 requests. The batch code then loses track
+        of all the duplicate requests being made and never resolves or rejects
+        the duplicate requests
+        https://github.com/nodkz/react-relay-network-layer/pull/52
+      */
+      requestMap[relayReqId].duplicates.push(requestWrapper);
+    } else {
+      requestMap[relayReqId] = requestWrapper;
+    }
+  });
+}
+
+function prepareNewBatcher(next, opts): Batcher {
+  const batcher: Batcher = {
+    bodySize: 2, // account for '[]'
+    requestMap: {},
+    acceptRequests: true,
+  };
+
+  setTimeout(() => {
+    batcher.acceptRequests = false;
+    sendRequests(batcher.requestMap, next, opts)
+      .then(() => finalizeUncompleted(batcher.requestMap))
+      .catch(() => finalizeUncompleted(batcher.requestMap));
+  }, opts.batchTimeout);
+
+  return batcher;
+}
+
+async function sendRequests(requestMap: BatchRequestMap, next, opts) {
+  const ids = Object.keys(requestMap);
+
+  if (ids.length === 1) {
+    // SEND AS SINGLE QUERY
+    const request = requestMap[ids[0]];
+
+    const res = await next(request.req);
+    request.completeOk(res);
+    request.duplicates.forEach((r) => r.completeOk(res));
+    return res;
+  } else if (ids.length > 1) {
+    // SEND AS BATCHED QUERY
+
+    const batchRequest = new RelayRequestBatch(ids.map((id) => requestMap[id].req));
+    // $FlowFixMe
+    const url = await (isFunction(opts.batchUrl) ? opts.batchUrl(requestMap) : opts.batchUrl);
+    batchRequest.setFetchOption('url', url);
+
+    const { headersOrThunk, ...fetchOpts } = opts.fetchOpts;
+    batchRequest.setFetchOptions(fetchOpts);
+
+    if (headersOrThunk) {
+      const headers = await (isFunction(headersOrThunk)
+        ? (headersOrThunk: any)(batchRequest)
+        : headersOrThunk);
+      batchRequest.setFetchOption('headers', headers);
+    }
+
+    try {
+      const batchResponse = await next(batchRequest);
+      if (!batchResponse || !Array.isArray(batchResponse.json)) {
+        throw new RRNLBatchMiddlewareError(
+          'Wrong response from server. Did your server support batch request?'
+        );
+      }
+
+      batchResponse.json.forEach((payload: any) => {
+        if (!payload) return;
+        const request = requestMap[payload.id];
+        if (request) {
+          const res = createSingleResponse(batchResponse, payload);
+          request.completeOk(res);
+        }
+      });
+
+      return batchResponse;
+    } catch (e) {
+      ids.forEach((id) => {
+        requestMap[id].completeErr(e);
+      });
+    }
+  }
+
+  return Promise.resolve();
+}
+
+// check that server returns responses for all requests
+function finalizeUncompleted(requestMap: BatchRequestMap) {
+  Object.keys(requestMap).forEach((id) => {
+    const request = requestMap[id];
+    if (!request.done) {
+      request.completeErr(
+        new RRNLBatchMiddlewareError(
+          `Server does not return response for request with id ${id} \n` +
+            `Response should have following shape { "id": "${id}", "data": {} }`
+        )
+      );
+    }
+  });
+}
+
+function createSingleResponse(batchResponse: RelayResponse, json: any): RelayResponse {
+  // Fallback for graphql-graphene and apollo-server batch responses
+  const data = json.payload || json;
+  const res = batchResponse.clone();
+  res.processJsonData(data);
+  return res;
+}

--- a/src/middlewares/legacyBatch.js
+++ b/src/middlewares/legacyBatch.js
@@ -6,7 +6,7 @@ import RelayRequestBatch from '../RelayRequestBatch';
 import RelayRequest from '../RelayRequest';
 import type RelayResponse from '../RelayResponse';
 import type { Middleware, FetchOpts } from '../definition';
-import RRNLError from '../RRNLError';
+import { RRNLBatchMiddlewareError } from './batch';
 
 // Max out at roughly 100kb (express-graphql imposed max)
 const DEFAULT_BATCH_SIZE = 102400;
@@ -45,14 +45,7 @@ type Batcher = {
   acceptRequests: boolean,
 };
 
-export class RRNLBatchMiddlewareError extends RRNLError {
-  constructor(msg: string) {
-    super(msg);
-    this.name = 'RRNLBatchMiddlewareError';
-  }
-}
-
-export default function batchMiddlewareLegacy(options?: BatchMiddlewareOpts): Middleware {
+export default function legacyBatchMiddleware(options?: BatchMiddlewareOpts): Middleware {
   const opts = options || {};
   const batchTimeout = opts.batchTimeout || 0; // 0 is the same as nextTick in nodeJS
   const allowMutations = opts.allowMutations || false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2405,7 +2405,7 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -3691,7 +3691,7 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -4798,11 +4798,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -4810,31 +4805,9 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -4868,11 +4841,6 @@ lodash.isstring@^4.0.1:
 lodash.map@^4.5.1:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -6447,7 +6415,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   dependencies:
@@ -6571,10 +6539,10 @@ regjsparser@^0.6.0:
   dependencies:
     jsesc "~0.5.0"
 
-relay-runtime@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-3.0.0.tgz#a024e1d80c9a71e76495f3a15e8f3f40113385e2"
-  integrity sha512-P9pDoAaqku9m5MTMjampwo+0vsNd2Nv8x78GpWuxPxvqJusqz8MBpu0RVBViIpLzCn77Pegw2ihtXgQSBdvs0w==
+relay-runtime@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-4.0.0.tgz#5cf50f52e3ea56ec81f0b5fed05b03e99a9e3906"
+  integrity sha512-Fd5nAMNfySINAYPf1zgtcYbCk33pO5ANiYfaMhKYzukfc2GCmn6RP7NEpG69GxVezu/E1aOxo72t+Y1NspDV8A==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^1.0.0"


### PR DESCRIPTION
* Tracks batch requests in Array instead of Map #31
* Determines duplicate requests based on body of request (which includes the request ID) #31, #48
