### PR TITLE
Fix request polling

### DIFF
--- a/src/RelayNetworkLayer.js
+++ b/src/RelayNetworkLayer.js
@@ -67,11 +67,11 @@ export default class RelayNetworkLayer {
         if (res) return res;
       }
 
-      const req = new RelayRequest(operation, variables, cacheConfig, uploadables);
-      const res = fetchWithMiddleware(req, this._middlewares, this._rawMiddlewares, this.noThrow);
-
       return {
         subscribe: (sink) => {
+          const req = new RelayRequest(operation, variables, cacheConfig, uploadables);
+          const res = fetchWithMiddleware(req, this._middlewares, this._rawMiddlewares, this.noThrow);
+
           res
             .then(
               (value) => {

--- a/src/RelayNetworkLayer.js
+++ b/src/RelayNetworkLayer.js
@@ -70,7 +70,12 @@ export default class RelayNetworkLayer {
       return {
         subscribe: (sink) => {
           const req = new RelayRequest(operation, variables, cacheConfig, uploadables);
-          const res = fetchWithMiddleware(req, this._middlewares, this._rawMiddlewares, this.noThrow);
+          const res = fetchWithMiddleware(
+            req,
+            this._middlewares,
+            this._rawMiddlewares,
+            this.noThrow
+          );
 
           res
             .then(

--- a/src/__tests__/RelayNetworkLayer-test.js
+++ b/src/__tests__/RelayNetworkLayer-test.js
@@ -21,7 +21,7 @@ describe('RelayNetworkLayer', () => {
     const mw2: any = jest.fn((next) => next);
 
     const network = new RelayNetworkLayer([null, mw1, undefined, mw2]);
-    await network.execute(mockOperation, {}, {});
+    await network.execute(mockOperation, {}, {}).toPromise();
     expect(mw1).toHaveBeenCalled();
     expect(mw2).toHaveBeenCalled();
   });
@@ -34,7 +34,7 @@ describe('RelayNetworkLayer', () => {
         execute: () => ({ data: {} }),
       };
       const network = new RelayNetworkLayer([syncMW, asyncMW]);
-      await network.execute(mockOperation, {}, {});
+      await network.execute(mockOperation, {}, {}).toPromise();
       expect(asyncMW).not.toHaveBeenCalled();
     });
 
@@ -46,7 +46,7 @@ describe('RelayNetworkLayer', () => {
       };
 
       const network = new RelayNetworkLayer([syncMW, asyncMW]);
-      await network.execute(mockOperation, {}, {});
+      await network.execute(mockOperation, {}, {}).toPromise();
       expect(asyncMW).toHaveBeenCalled();
     });
   });
@@ -58,7 +58,7 @@ describe('RelayNetworkLayer', () => {
       const network = new RelayNetworkLayer([asyncMW], {
         beforeFetch: () => ({ data: {} }),
       });
-      await network.execute(mockOperation, {}, {});
+      await network.execute(mockOperation, {}, {}).toPromise();
       expect(asyncMW).not.toHaveBeenCalled();
     });
 
@@ -68,7 +68,7 @@ describe('RelayNetworkLayer', () => {
       const network = new RelayNetworkLayer([asyncMW], {
         beforeFetch: () => undefined,
       });
-      await network.execute(mockOperation, {}, {});
+      await network.execute(mockOperation, {}, {}).toPromise();
       expect(asyncMW).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
Polling in relay is implemented by resubscribing to the observable so we need to make sure to create a new request each time otherwise stale data is returned (see https://github.com/facebook/relay/blob/aef8a5e33763e9d9a4e1e294913cbdbdb5634ecc/packages/relay-runtime/network/RelayObservable.js#L398).

This also fixes tests since network.execute returns an Observable and not a Promise.