### PR TITLE
Fix `isMutation` when using persisted queries

### DIFF
--- a/src/RelayRequest.js
+++ b/src/RelayRequest.js
@@ -98,7 +98,7 @@ export default class RelayRequest {
   }
 
   isMutation(): boolean {
-    return this.getQueryString().startsWith('mutation');
+    return this.operation.operationKind === 'mutation';
   }
 
   isFormData(): boolean {

--- a/src/__mocks__/mockReq.js
+++ b/src/__mocks__/mockReq.js
@@ -52,9 +52,12 @@ class MockReq {
   }
 
   execute(rnl: RelayNetworkLayer): Promise<RelayResponse> {
+    const text = this.getQueryString() || '';
+    const operationKind = text.startsWith('mutation') ? 'mutation' : 'query';
     const operation = ({
       id: this.getID(),
-      text: this.getQueryString() || '',
+      text,
+      operationKind,
     }: any);
     const variables = this.getVariables() || {};
     const cacheConfig = {};

--- a/src/middlewares/__tests__/__snapshots__/logger-test.js.snap
+++ b/src/middlewares/__tests__/__snapshots__/logger-test.js.snap
@@ -23,6 +23,7 @@ Array [
       "id": "MyRequest",
       "operation": Object {
         "id": "MyRequest",
+        "operationKind": "query",
         "text": "",
       },
       "uploadables": undefined,

--- a/src/middlewares/__tests__/__snapshots__/perf-test.js.snap
+++ b/src/middlewares/__tests__/__snapshots__/perf-test.js.snap
@@ -20,6 +20,7 @@ RelayRequest {
   "id": "MyRequest",
   "operation": Object {
     "id": "MyRequest",
+    "operationKind": "query",
     "text": "",
   },
   "uploadables": undefined,


### PR DESCRIPTION
Using the query text to check if a request is a mutation doesn't work when using persisted queries since the query text will be empty. Instead we can use `operation.operationKind` which is always set properly.