### PR TITLE
⚡️ make react-relay an optional dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
   "homepage": "https://github.com/relay-tools/react-relay-network-modern#readme",
   "dependencies": {},
   "optionalDependencies": {
-    "@types/relay-runtime": "^5.0.3",
-    "react-relay": ">=1.4.0"
+    "@types/relay-runtime": "^5.0.3"
+  },
+  "peerDependencies": {
+    "relay-runtime": ">=1.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,9 @@
   },
   "homepage": "https://github.com/relay-tools/react-relay-network-modern#readme",
   "dependencies": {},
-  "peerDependencies": {
-    "react-relay": ">=1.4.0"
-  },
   "optionalDependencies": {
-    "@types/relay-runtime": "^5.0.3"
+    "@types/relay-runtime": "^5.0.3",
+    "react-relay": ">=1.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/src/RelayNetworkLayer.js
+++ b/src/RelayNetworkLayer.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { Network } from 'relay-runtime'; // eslint-disable-line
+import { Network } from 'relay-runtime';
 import RelayRequest from './RelayRequest';
 import fetchWithMiddleware from './fetchWithMiddleware';
 import type {

--- a/src/middlewares/cache.js
+++ b/src/middlewares/cache.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { QueryResponseCache } from 'relay-runtime'; // eslint-disable-line import/no-extraneous-dependencies
+import { QueryResponseCache } from 'relay-runtime';
 import type { Middleware } from '../definition';
 import { isFunction } from '../utils';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1219,6 +1219,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/relay-runtime@^5.0.3":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@types/relay-runtime/-/relay-runtime-5.0.5.tgz#62fb80d4925a707583e535f6d0afdf0762467adb"
+  integrity sha512-ZfhRGH8kYnMUeV3NBSYsy99hvJ/GiWAZ4Kc7KG7SuKXdYAHNuHV69TJnHmnmuh54EZytu3NplYDwccerghykpQ==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"


### PR DESCRIPTION
### Description
- ⚡️ make react-relay an optional dep

This package supports being used by a nodeJS project to support batching. Having react-relay as a peer dependency causes a waring in nodeJS projects that don't have/require react-relay.