### PR TITLE
Expose the `Headers` type so it can be used in the URL middleware.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,10 +13,11 @@ declare class RelayResponse {
 }
 export { RelayResponse as RelayNetworkLayerResponse };
 
+export type Headers = { [name: string]: string };
 export interface FetchOpts {
   url?: string;
   method: 'POST' | 'GET';
-  headers: { [name: string]: string };
+  headers: Headers;
   body: string | FormData;
   credentials?: 'same-origin' | 'include' | 'omit';
   mode?: 'cors' | 'websocket' | 'navigate' | 'no-cors' | 'same-origin';


### PR DESCRIPTION
The `Headers` type was not being exported in the TypeScript definition, so there ways no good way of creating the headers. This PR exposes the type and makes it clear that `FetchOpts#headers` should use that newly exposed type. The change makes the type equivalent to the Flow version exposed elsewhere in the code.