### PR TITLE
Remove unnecessary optional dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
   "dependencies": {
     "extract-files": "^5.0.1"
   },
-  "optionalDependencies": {
-    "@types/relay-runtime": "^5.0.3"
-  },
   "peerDependencies": {
     "relay-runtime": ">=1.4.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1219,11 +1219,6 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
-"@types/relay-runtime@^5.0.3":
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/@types/relay-runtime/-/relay-runtime-5.0.5.tgz#62fb80d4925a707583e535f6d0afdf0762467adb"
-  integrity sha512-ZfhRGH8kYnMUeV3NBSYsy99hvJ/GiWAZ4Kc7KG7SuKXdYAHNuHV69TJnHmnmuh54EZytu3NplYDwccerghykpQ==
-
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"


### PR DESCRIPTION
I don't know if this optional dependency is required, but I suspect not. Anyone using Relay with TypeScript has almost certainly added `@types/relay-runtime` directly as a dependency or dev dependency in their own `package.json`. Since this project isn't really bound to much of Relay's internals, it doesn't need to be updated at the same frequency as `@types/relay-runtime`. By listing `@types/relay-runtime` as an optional dependency of this project, however, it will forever be in conflict with anyone needing a different version of `@types/relay-runtime` (see #81).