### PR TITLE
Update TypeScript definition of `RelayResponse` to match Flow definition.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,12 +4,26 @@ export type FetchResponse = Response;
 export type Variables = { [name: string]: any };
 
 declare class RelayResponse {
+  _res: any;
+
+  data?: PayloadData;
+  errors?: any[];
+
+  ok: any;
+  status: number;
+  statusText?: string;
+  headers?: Headers;
+  url?: string;
+  text?: string;
+  json: unknown;
+
   static createFromFetch(res: FetchResponse): Promise<RelayResponse>;
 
   static createFromGraphQL(res: { errors?: any; data?: any }): Promise<RelayResponse>;
 
-  processJsonData(json: any): void;
+  processJsonData(json: unknown): void;
   clone(): RelayResponse;
+  toString(): string;
 }
 export { RelayResponse as RelayNetworkLayerResponse };
 


### PR DESCRIPTION
I believe this PR brings the TypeScript definition of `RelayResponse` up to date with the Flow definition, fixing #86. For the most part, I just added the missing fields and functions. I did re-type `json` from `any` to `unknown` to better match the semantics of the Flow definition. If this problematic, I back that out again.

I also left the type of `ok` as `any` to match the Flow definition, but I've only ever seen it being a `boolean`. Can it be anything other than a boolean value? If so, could it be better be represented as a union type rather than `any`?