### PR TITLE
Expose error creation functions

### DIFF
--- a/src/RelayResponse.js
+++ b/src/RelayResponse.js
@@ -1,12 +1,12 @@
 /* @flow */
 
-import type { PayloadData, FetchResponse } from './definition';
+import type { FetchResponse, GraphQLResponseErrors, PayloadData } from './definition';
 
 export default class RelayResponse {
   _res: any; // response from low-level method, eg. fetch
 
   data: ?PayloadData;
-  errors: ?Array<any>;
+  errors: ?GraphQLResponseErrors;
 
   ok: any;
   status: number;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,7 +7,7 @@ declare class RelayResponse {
   _res: any;
 
   data?: PayloadData;
-  errors?: any[];
+  errors?: GraphQLResponseErrors;
 
   ok: any;
   status: number;
@@ -146,7 +146,7 @@ export type BatchMiddlewareOpts = {
   allowMutations?: boolean;
   method?: 'POST' | 'GET';
   headers?: Headers | Promise<Headers> | ((req: RelayRequestBatch) => Headers | Promise<Headers>);
-  // Avaliable request modes in fetch options. For details see https://fetch.spec.whatwg.org/#requests
+  // Available request modes in fetch options. For details see https://fetch.spec.whatwg.org/#requests
   credentials?: FetchOpts['credentials'];
   mode?: FetchOpts['mode'];
   cache?: FetchOpts['cache'];
@@ -296,3 +296,12 @@ export class RelayNetworkLayer {
 
   execute: ExecuteFunction;
 }
+
+export type GraphQLResponseErrors = Array<{
+  message: string;
+  locations?: [{ column: number; line: number }];
+  stack?: string[];
+}>;
+
+export function createRequestError(request: RelayRequestAny, response?: RelayResponse);
+export function formatGraphQLErrors(request: RelayRequest, errors: GraphQLResponseErrors);

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ import graphqlBatchHTTPWrapper from './express-middleware/graphqlBatchHTTPWrappe
 import RelayNetworkLayerRequest from './RelayRequest';
 import RelayNetworkLayerRequestBatch from './RelayRequestBatch';
 import RelayNetworkLayerResponse from './RelayResponse';
-import { RRNLRequestError } from './createRequestError';
+import { createRequestError, formatGraphQLErrors, RRNLRequestError } from './createRequestError';
 import RRNLError from './RRNLError';
 
 export {
@@ -36,6 +36,8 @@ export {
   progressMiddleware,
   uploadMiddleware,
   graphqlBatchHTTPWrapper,
+  createRequestError,
+  formatGraphQLErrors,
   RRNLError,
   RRNLRequestError,
   RRNLRetryMiddlewareError,


### PR DESCRIPTION
I don't know if you really want to expose this functionality or not, but it helps me address the problem I raised in #88. With this change, I can add custom middleware to do the following:

```
next => async req => {
  Sentry.setTag('graphql_query', req.getID())

  try {
    const res = await next(req)

    if (res.errors) {
      const error = createRequestError(req, res)
      Sentry.captureException(error)
    }

    return res
  } catch (e) {
    Sentry.captureException(e)
    throw e
  }
}
```

Or:

```
next => async req => {
  Sentry.setTag('graphql_query', req.getID())

  try {
    const res = await next(req)

    if (res.errors) {
      const errorMessage =
        req instanceof RelayNetworkLayerRequest
          ? formatGraphQLErrors(req, res.errors)
          : JSON.stringify(res.errors)
      Sentry.captureMessage(errorMessage)
    }

    return res
  } catch (e) {
    Sentry.captureException(e)
    throw e
  }
}
```

That conditional creation of the error message comes from the implementation of `createRequestError`. I don't really like that it needs to do an `instanceof` check, but it's unavoidable without changing the type definition for `formatGraphQLErrors`.

I also am not 100% certain that I've provided the correct type for `RelayResponse#errors`. As far as I can tell, I did. The type definition appears to match what I saw in the debugger. But, I don't know if the field was typed as `any` for any particular reason.