### PR TITLE
Handle canceled requests better

### DIFF
--- a/src/middlewares/retry.js
+++ b/src/middlewares/retry.js
@@ -146,7 +146,7 @@ async function makeRetriableRequest(
       });
     } catch (e) {
       // no response from server (no internet connection), make new attempt
-      if (e && !e.res && !(e instanceof RRNLRetryMiddlewareError)) {
+      if (e && !e.res && !(e instanceof RRNLRetryMiddlewareError) && e.name !== 'AbortError') {
         return makeRetry(e);
       }
 


### PR DESCRIPTION
When a request is canceled, the `AbortError` bubbles up and both the `batch` and `retry` middlewares don't let it continue to bubble up.