### PR TITLE
Add `skipBatch` to cacheConfig options

### DIFF
--- a/src/__mocks__/mockReq.js
+++ b/src/__mocks__/mockReq.js
@@ -3,10 +3,12 @@
 
 import type RelayNetworkLayer from '../RelayNetworkLayer';
 import type RelayResponse from '../RelayResponse';
+import type { CacheConfig } from '../definition';
 
 type ReqData = {
   query?: string,
   variables?: Object,
+  cacheConfig?: CacheConfig,
   files?: any,
 };
 
@@ -17,6 +19,7 @@ class MockReq {
   reqData: ReqData;
   error: Error;
   payload: Object;
+  cacheConfig: Object;
 
   constructor(reqid?: ReqId, reqData?: ReqData = {}) {
     this.reqid = reqid || Math.random().toString();
@@ -60,7 +63,7 @@ class MockReq {
       operationKind,
     }: any);
     const variables = this.getVariables() || {};
-    const cacheConfig = {};
+    const cacheConfig = this.reqData.cacheConfig || {};
     const uploadables = this.getFiles();
 
     const res = (rnl.fetchFn(operation, variables, cacheConfig, uploadables): any);

--- a/src/definition.js
+++ b/src/definition.js
@@ -88,6 +88,7 @@ export type CacheConfig = {
   force?: ?boolean,
   poll?: ?number,
   rerunParamExperimental?: ?any,
+  skipBatch?: ?boolean,
 };
 export type Disposable = { dispose(): void };
 export type Uploadable = File | Blob;

--- a/src/middlewares/batch.js
+++ b/src/middlewares/batch.js
@@ -84,6 +84,11 @@ export default function batchMiddleware(options?: BatchMiddlewareOpts): Middlewa
       return next(req);
     }
 
+    // skip batching if request explicitly opts out
+    if (req.cacheConfig.skipBatch) {
+      return next(req);
+    }
+
     return passThroughBatch(req, next, {
       batchTimeout,
       batchUrl,


### PR DESCRIPTION
When `cacheConfig.skipBatch` is truthy, we skip batching for that request even when the batchMiddleware is present. This allows users to better control what requests are batched together.

Use case: 

We have a bunch of `QueryRenderer`s on the page at once. Some of those queries are very fast, but a couple of them are very slow. When they're all batched together those fast queries are now just as slow as the slowest query in the batch. This allows us to skip batching for those very fast queries so that user's get a snappier experience.

Fixes #80 

This is my first PR on this project so please let me know what I may have missed or what I can do to further help!