### PR TITLE
Adds the operationKind property to ConcreteBatch type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -231,6 +231,7 @@ export type ConcreteBatch = {
   name: string;
   query: any;
   text: string | null;
+  operationKind: string;
 };
 export type CacheConfig = {
   force?: boolean;


### PR DESCRIPTION
Adds the [`operationKind`](https://github.com/relay-tools/react-relay-network-modern/blob/488944f89f40639e9c87319363709c68f366e312/src/definition.js#L85) property which was missing.