### PR TITLE
Exporting RelayNetworkLayerOpts to be used externally

### DIFF
--- a/src/RelayNetworkLayer.js
+++ b/src/RelayNetworkLayer.js
@@ -13,7 +13,7 @@ import type {
   RNLExecuteFunction,
 } from './definition';
 
-type RelayNetworkLayerOpts = {|
+export type RelayNetworkLayerOpts = {|
   subscribeFn?: SubscribeFunction,
   beforeFetch?: FetchHookFunction,
   noThrow?: boolean,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -283,7 +283,7 @@ export type SubscribeFunction = (
   observer: any
 ) => RelayObservable<QueryPayload> | Disposable;
 
-type RelayNetworkLayerOpts = {
+export type RelayNetworkLayerOpts = {
   subscribeFn?: SubscribeFunction;
   beforeFetch?: FetchHookFunction;
   noThrow?: boolean;


### PR DESCRIPTION
RelayNetworkLayerOpts should be exposed externally so that wrapper application can simply extend the type.
Currently, types have to be copied from the package and into the application