### PR TITLE
graphqlBatchHTTPWrapper

### DIFF
--- a/src/express-middleware/graphqlBatchHTTPWrapper.js
+++ b/src/express-middleware/graphqlBatchHTTPWrapper.js
@@ -15,6 +15,7 @@ export default function(graphqlHTTPMiddleware: ExpressMiddleware): ExpressMiddle
               body: data,
             };
             const subResponse = {
+              ...res,
               status(st) {
                 this.statusCode = st;
                 return this;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -314,3 +314,6 @@ export class RRNLRequestError extends RRNLError {
 
 export function createRequestError(request: RelayRequestAny, response?: RelayResponse): RRNLRequestError;
 export function formatGraphQLErrors(request: RelayRequest, errors: GraphQLResponseErrors): string;
+
+type ExpressMiddleware = (req: any, res: any) => any;
+export function graphqlBatchHTTPWrapper(middleware: ExpressMiddleware): ExpressMiddleware;


### PR DESCRIPTION
Two minor changes here concerning `graphqlBatchHTTPWrapper`

* We want to spread the existing `res` so as to not lose any thing that is, for instance, stored on `res.locals` which middleware up the stack might stick on the response.
* Exposes its TS type