### PR TITLE
Fix formatGraphQLErrors for persisted queries

### DIFF
--- a/src/createRequestError.js
+++ b/src/createRequestError.js
@@ -26,9 +26,10 @@ export function formatGraphQLErrors(request: RelayRequest, errors: GraphQLRespon
     return errors.join('\n');
   }
 
-  const queryString = request.getQueryString();
   let queryLines = [];
+  const queryString = request.getQueryString();
   if (queryString) {
+    // When using persisted query, queryString is an empty string.
     queryLines = queryString.split('\n');
   }
 

--- a/src/createRequestError.js
+++ b/src/createRequestError.js
@@ -27,10 +27,10 @@ export function formatGraphQLErrors(request: RelayRequest, errors: GraphQLRespon
   }
 
   const queryString = request.getQueryString();
-  if (!queryString) {
-    return errors.join('\n');
+  let queryLines = [];
+  if (queryString) {
+    queryLines = queryString.split('\n');
   }
-  const queryLines = [];
 
   return errors
     .map(({ locations, message }, ii) => {
@@ -38,21 +38,22 @@ export function formatGraphQLErrors(request: RelayRequest, errors: GraphQLRespon
       const indent = ' '.repeat(prefix.length);
 
       // custom errors thrown in graphql-server may not have locations
-      const locationMessage = locations
-        ? '\n' +
-          locations
-            .map(({ column, line }) => {
-              const queryLine = queryLines[line - 1];
-              const offset = Math.min(column - 1, CONTEXT_BEFORE);
-              return [
-                queryLine.substr(column - 1 - offset, CONTEXT_LENGTH),
-                `${' '.repeat(Math.max(offset, 0))}^^^`,
-              ]
-                .map((messageLine) => indent + messageLine)
-                .join('\n');
-            })
-            .join('\n')
-        : '';
+      const locationMessage =
+        locations && queryLines.length
+          ? '\n' +
+            locations
+              .map(({ column, line }) => {
+                const queryLine = queryLines[line - 1];
+                const offset = Math.min(column - 1, CONTEXT_BEFORE);
+                return [
+                  queryLine.substr(column - 1 - offset, CONTEXT_LENGTH),
+                  `${' '.repeat(Math.max(offset, 0))}^^^`,
+                ]
+                  .map((messageLine) => indent + messageLine)
+                  .join('\n');
+              })
+              .join('\n')
+          : '';
       return prefix + message + locationMessage;
     })
     .join('\n');

--- a/src/createRequestError.js
+++ b/src/createRequestError.js
@@ -26,12 +26,11 @@ export function formatGraphQLErrors(request: RelayRequest, errors: GraphQLRespon
     return errors.join('\n');
   }
 
-  let queryLines = [];
   const queryString = request.getQueryString();
-  if (queryString) {
-    // When using persisted query, queryString is an empty string.
-    queryLines = queryString.split('\n');
+  if (!queryString) {
+    return errors.join('\n');
   }
+  const queryLines = [];
 
   return errors
     .map(({ locations, message }, ii) => {


### PR DESCRIPTION
This seemingly was introduced in a9a036ff1a02f0be5e9fe9b667b1bf2ec6a2d2b8. Persisted queries do not have a query body, and therefore the `queryLine.subtr` later on fails.

To fix this, I only applied the error locations mapping when there are queryLines present.