### PR TITLE
Error should not be thrown on HTTP error when noThrow is set.

### DIFF
--- a/src/__tests__/fetchWithMiddleware-test.js
+++ b/src/__tests__/fetchWithMiddleware-test.js
@@ -93,7 +93,7 @@ describe('fetchWithMiddleware', () => {
     }
   });
 
-  it('should not throw if noThrow set', async () => {
+  it('should not throw on GraphQL error if noThrow set', async () => {
     fetchMock.mock({
       matcher: '/graphql',
       response: {
@@ -110,6 +110,23 @@ describe('fetchWithMiddleware', () => {
     expect.assertions(1);
     const res = await fetchWithMiddleware(req, [], [], true);
     expect(res.errors).toEqual([{ location: 1, message: 'major error' }]);
+  });
+
+  it('should not throw on HTTP error if noThrow set', async () => {
+    fetchMock.mock({
+      matcher: '/graphql',
+      response: {
+        status: 500,
+        body: 'Something went completely wrong.',
+      },
+      method: 'POST',
+    });
+
+    const req = new RelayRequest(({}: any), {}, {}, null);
+
+    expect.assertions(1);
+    const res = await fetchWithMiddleware(req, [], [], true);
+    expect(res.status).toEqual(500);
   });
 
   it('should handle server non-2xx errors', async () => {

--- a/src/fetchWithMiddleware.js
+++ b/src/fetchWithMiddleware.js
@@ -25,11 +25,13 @@ function runFetch(req: RelayRequestAny): Promise<FetchResponse> {
 }
 
 // convert fetch response to RelayResponse object
-const convertResponse: (next: MiddlewareRawNextFn) => MiddlewareNextFn = (next) => async (req) => {
+const convertResponse: (noThrow?: boolean) => (next: MiddlewareRawNextFn) => MiddlewareNextFn = (
+  noThrow
+) => (next) => async (req) => {
   const resFromFetch = await next(req);
 
   const res = await RelayResponse.createFromFetch(resFromFetch);
-  if (res.status && res.status >= 400) {
+  if (!noThrow && res.status && res.status >= 400) {
     throw createRequestError(req, res);
   }
   return res;
@@ -44,7 +46,7 @@ export default function fetchWithMiddleware(
   // $FlowFixMe
   const wrappedFetch: MiddlewareNextFn = compose(
     ...middlewares,
-    convertResponse,
+    convertResponse(noThrow),
     ...rawFetchMiddlewares
   )((runFetch: any));
 


### PR DESCRIPTION
I noticed that the noThrow flag only disable throwing for GraphQL errors in the response. For HTTP errors codes coming back from the server an error will be thrown currently even though you set the flag. 

In my opinion it makes sense to do the same for HTTP errors in the response. You either handle all the errors yourself or you let the middleware stack throw errors.