### PR TITLE
Add `updateTTLOnGet` argument to cache middleware 

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ import { RelayNetworkLayer } from 'react-relay-network-modern/es';
   - `allowFormData` - allow to cache FormData requests (default: `false`)
   - `clearOnMutation` - clear the cache on any Mutation (default: `false`)
   - `cacheErrors` - cache responses with errors (default: `false`)
+  - `updateTTLOnGet` - refresh cache ttl on queries on successful cache get (default: `false`)
 - **authMiddleware** - for adding auth token, and refreshing it if gets 401 response from server.
   - `token` - string which returns token. Can be function(req) or Promise. If function is provided, then it will be called for every request (so you may change tokens on fly).
   - `tokenRefreshPromise`: - function(req, res) which must return promise or regular value with a new token. This function is called when server returns 401 status code. After receiving a new token, middleware re-run query to the server seamlessly for Relay.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-import { ExecuteFunction, QueryResponseCache } from 'relay-runtime';
+import { ExecuteFunction, QueryResponseCache } from "relay-runtime";
 
 export { QueryResponseCache };
 
@@ -248,10 +248,10 @@ export type PayloadData = { [key: string]: any };
 
 export type QueryPayload =
   | {
-      data?: PayloadData | null;
-      errors?: any[];
-      rerunVariables?: Variables;
-    }
+    data?: PayloadData | null;
+    errors?: any[];
+    rerunVariables?: Variables;
+  }
   | RelayResponse;
 
 export type MiddlewareSync = {
@@ -288,11 +288,12 @@ export type RelayNetworkLayerOpts = {
 };
 
 export class RelayNetworkLayer {
-  execute: ExecuteFunction;
   constructor(
     middlewares: Array<Middleware | MiddlewareSync | MiddlewareRaw | null>,
     opts?: RelayNetworkLayerOpts
   );
+
+  execute: ExecuteFunction;
 }
 
 export type GraphQLResponseErrors = Array<{
@@ -312,10 +313,7 @@ export class RRNLRequestError extends RRNLError {
   constructor(msg: string);
 }
 
-export function createRequestError(
-  request: RelayRequestAny,
-  response?: RelayResponse
-): RRNLRequestError;
+export function createRequestError(request: RelayRequestAny, response?: RelayResponse): RRNLRequestError;
 export function formatGraphQLErrors(request: RelayRequest, errors: GraphQLResponseErrors): string;
 
 type ExpressMiddleware = (req: any, res: any) => any;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-import { ExecuteFunction, QueryResponseCache } from "relay-runtime";
+import { ExecuteFunction, QueryResponseCache } from 'relay-runtime';
 
 export { QueryResponseCache };
 
@@ -160,6 +160,7 @@ export interface CacheMiddlewareOpts {
   allowFormData?: boolean;
   clearOnMutation?: boolean;
   cacheErrors?: boolean;
+  updateTTLOnGet?: boolean;
 }
 
 export function cacheMiddleware(opts?: CacheMiddlewareOpts): Middleware;
@@ -247,10 +248,10 @@ export type PayloadData = { [key: string]: any };
 
 export type QueryPayload =
   | {
-    data?: PayloadData | null;
-    errors?: any[];
-    rerunVariables?: Variables;
-  }
+      data?: PayloadData | null;
+      errors?: any[];
+      rerunVariables?: Variables;
+    }
   | RelayResponse;
 
 export type MiddlewareSync = {
@@ -287,12 +288,11 @@ export type RelayNetworkLayerOpts = {
 };
 
 export class RelayNetworkLayer {
+  execute: ExecuteFunction;
   constructor(
     middlewares: Array<Middleware | MiddlewareSync | MiddlewareRaw | null>,
     opts?: RelayNetworkLayerOpts
   );
-
-  execute: ExecuteFunction;
 }
 
 export type GraphQLResponseErrors = Array<{
@@ -312,7 +312,10 @@ export class RRNLRequestError extends RRNLError {
   constructor(msg: string);
 }
 
-export function createRequestError(request: RelayRequestAny, response?: RelayResponse): RRNLRequestError;
+export function createRequestError(
+  request: RelayRequestAny,
+  response?: RelayResponse
+): RRNLRequestError;
 export function formatGraphQLErrors(request: RelayRequest, errors: GraphQLResponseErrors): string;
 
 type ExpressMiddleware = (req: any, res: any) => any;

--- a/src/middlewares/cache.js
+++ b/src/middlewares/cache.js
@@ -12,11 +12,20 @@ type CacheMiddlewareOpts = {|
   allowFormData?: boolean,
   clearOnMutation?: boolean,
   cacheErrors?: boolean,
+  updateTTLOnGet?: boolean,
 |};
 
 export default function cacheMiddleware(opts?: CacheMiddlewareOpts): Middleware {
-  const { size, ttl, onInit, allowMutations, allowFormData, clearOnMutation, cacheErrors } =
-    opts || {};
+  const {
+    size,
+    ttl,
+    onInit,
+    allowMutations,
+    allowFormData,
+    clearOnMutation,
+    cacheErrors,
+    updateTTLOnGet,
+  } = opts || {};
   const cache = new QueryResponseCache({
     size: size || 100, // 100 requests
     ttl: ttl || 15 * 60 * 1000, // 15 minutes
@@ -57,6 +66,10 @@ export default function cacheMiddleware(opts?: CacheMiddlewareOpts): Middleware 
 
       const cachedRes = cache.get(queryId, variables);
       if (cachedRes) {
+        if (updateTTLOnGet) {
+          cache.set(queryId, variables, cachedRes);
+        }
+
         return cachedRes;
       }
 


### PR DESCRIPTION
## Change

Add `updateTTLOnGet` argument to cache middleware to reset the TTL on cache payloads when fetched from cache

## Why?

It is sometimes desired to keep items in cache for extended periods of time, longer than the typical TTL without refetching them after the first fetch.

cc @nodkz 