### PR TITLE
escape process.env.NODE_ENV to solve the error when using with vitejs

### DIFF
--- a/src/middlewares/error.js
+++ b/src/middlewares/error.js
@@ -85,7 +85,7 @@ function noticeAbsentStack() {
       schema: myGraphQLSchema,
       formatError: (error) => ({
         message: error.message,
-        stack: process.env.NODE_ENV === 'development' ? error.stack.split('\\n') : null,
+        stack: process.env\u200b.NODE_ENV === 'development' ? error.stack.split('\\n') : null,
       })
     });
 


### PR DESCRIPTION
In `middlewares/error.js` `noticeAbsentStack` function, it return a string with stack: `process.env.NODE_ENV`.

When using the packages with vitejs, it will automatically replace the `process.env.NODE_ENV` string with something like this `"development"`, which cause `Uncaught SyntaxError: Unexpected identifier error`.
more details here: https://vitejs.dev/guide/env-and-mode.html#env-variables

Suggested by vitejs, we can break the string up with a unicode zero-width space, e.g. `'import.meta\u200b.env.MODE'`

