### PR TITLE
Ensure GET requests do not include a body

### DIFF
--- a/src/fetchWithMiddleware.js
+++ b/src/fetchWithMiddleware.js
@@ -13,15 +13,20 @@ import type {
 } from './definition';
 
 function runFetch(req: RelayRequestAny): Promise<FetchResponse> {
-  let { url } = req.fetchOpts;
+  let { url, body, ...fetchOpts } = req.fetchOpts;
   if (!url) url = '/graphql';
 
-  if (!req.fetchOpts.headers.Accept) req.fetchOpts.headers.Accept = '*/*';
-  if (!req.fetchOpts.headers['Content-Type'] && !req.isFormData()) {
-    req.fetchOpts.headers['Content-Type'] = 'application/json';
+  if (!fetchOpts.headers.Accept) fetchOpts.headers.Accept = '*/*';
+
+  if (fetchOpts.method === 'GET') {
+    return fetch(url, (fetchOpts: any));
   }
 
-  return fetch(url, (req.fetchOpts: any));
+  if (!fetchOpts.headers['Content-Type'] && !req.isFormData()) {
+    fetchOpts.headers['Content-Type'] = 'application/json';
+  }
+
+  return fetch(url, ({ ...fetchOpts, body }: any));
 }
 
 // convert fetch response to RelayResponse object

--- a/src/middlewares/__tests__/__snapshots__/batch-test.js.snap
+++ b/src/middlewares/__tests__/__snapshots__/batch-test.js.snap
@@ -8,7 +8,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -49,7 +48,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -64,7 +62,6 @@ Array [
         "Content-Type": "application/json",
       },
       "method": "POST",
-      "url": "/graphql/batch",
     },
   ],
   Array [
@@ -76,7 +73,6 @@ Array [
         "Content-Type": "application/json",
       },
       "method": "POST",
-      "url": "/graphql/batch",
     },
   ],
 ]
@@ -90,7 +86,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -102,7 +97,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -114,7 +108,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -126,7 +119,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -150,7 +142,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -162,7 +153,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -174,6 +164,5 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;

--- a/src/middlewares/__tests__/__snapshots__/legacyBatch-test.js.snap
+++ b/src/middlewares/__tests__/__snapshots__/legacyBatch-test.js.snap
@@ -8,7 +8,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -49,7 +48,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -64,7 +62,6 @@ Array [
         "Content-Type": "application/json",
       },
       "method": "POST",
-      "url": "/graphql/batch",
     },
   ],
   Array [
@@ -76,7 +73,6 @@ Array [
         "Content-Type": "application/json",
       },
       "method": "POST",
-      "url": "/graphql/batch",
     },
   ],
 ]
@@ -90,7 +86,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -102,7 +97,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -114,7 +108,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -126,7 +119,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -150,7 +142,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -162,7 +153,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -174,7 +164,6 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;
 
@@ -186,6 +175,5 @@ Object {
     "Content-Type": "application/json",
   },
   "method": "POST",
-  "url": "/graphql/batch",
 }
 `;

--- a/src/middlewares/__tests__/__snapshots__/url-test.js.snap
+++ b/src/middlewares/__tests__/__snapshots__/url-test.js.snap
@@ -2,14 +2,11 @@
 
 exports[`middlewares/url \`method\` option 1`] = `
 Object {
-  "body": "{\\"id\\":\\"1\\",\\"query\\":\\"\\",\\"variables\\":{}}",
   "headers": Object {
     "Accept": "*/*",
-    "Content-Type": "application/json",
   },
   "method": "GET",
   "signal": AbortSignal {},
-  "url": "/get_url",
 }
 `;
 
@@ -22,7 +19,6 @@ Object {
   },
   "method": "POST",
   "signal": AbortSignal {},
-  "url": "/some_url",
 }
 `;
 
@@ -35,7 +31,6 @@ Object {
   },
   "method": "POST",
   "signal": AbortSignal {},
-  "url": "/thunk_url",
 }
 `;
 
@@ -48,6 +43,5 @@ Object {
   },
   "method": "POST",
   "signal": AbortSignal {},
-  "url": "/thunk_url_promise",
 }
 `;


### PR DESCRIPTION
When a middleware changes the `req.fetchOpts.method` to `GET`, at the moment, it will try to send the `body` parameter down to `fetch` which causes an error:

```
TypeError: Window.fetch: HEAD or GET Request cannot have a body.
```

This change ensures that requests sent as `GET` will not include the `body`.