### PR TITLE
Update typescript types to support fetchTimeout TimeoutAfterFn

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -180,6 +180,7 @@ export interface GqlErrorMiddlewareOpts {
 export function errorMiddleware(opts?: GqlErrorMiddlewareOpts): Middleware;
 
 export type RetryAfterFn = (attempt: number) => number | false;
+export type TimeoutAfterFn = (attempt: number) => number;
 export type ForceRetryFn = (runNow: Function, delay: number) => any;
 export type AbortFn = (msg?: string) => any;
 
@@ -199,7 +200,7 @@ export type StatusCheckFn = (
 ) => boolean;
 
 export interface RetryMiddlewareOpts {
-  fetchTimeout?: number;
+  fetchTimeout?: number | TimeoutAfterFn;
   retryDelays?: number[] | RetryAfterFn;
   statusCodes?: number[] | false | StatusCheckFn;
   logger?: Function | false;


### PR DESCRIPTION
Flow types already indicated `fetchTimeout` in `RetryMiddlewareOpts` could be a function of attempt (instead of just a number). This exposes that in the typescript types as well.